### PR TITLE
closes #14: Avoid loosing data with accidental double click

### DIFF
--- a/src/main/webapp/resources/css/styles.css
+++ b/src/main/webapp/resources/css/styles.css
@@ -176,8 +176,8 @@ textarea:focus {
 .icon {
     display: inline-block;
     float: left;
-    min-height: 17px;
-    min-width: 17px;
+    min-height: 16px;
+    min-width: 16px;
     vertical-align: top;
     cursor: pointer;
     cursor: hand;
@@ -273,7 +273,7 @@ div.stakeholders {
 
 select.contributorSite,select.customerSite,select.status,select.prio,select.effort
     {
-    height: 23px;
+    height: 26px;
 }
 
 input.added,input.deadline,input.customer,input.contributor {
@@ -388,7 +388,7 @@ div#titleDivThemeEpic {
 }
 
 select.status,select.prio,select.effort {
-    height: 23px;
+    height: 26px;
 }
 
 .ui-button .ui-button-text {

--- a/src/main/webapp/resources/js/scripts-areaedit.js
+++ b/src/main/webapp/resources/js/scripts-areaedit.js
@@ -22,7 +22,7 @@
  *  THE SOFTWARE.
  */
 $(document).ready(function() {
-    $('#logout').button();
+    $('#login-out').button();
     $("#add-admin").button();
     $("#add-editor").button();
 

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -1740,6 +1740,11 @@ $(document).ready(function () {
         	event.stopPropagation();
         });
 
+        //This avoids exiting edit mode if an element inside a theme, epic, story or task is double clicked.
+        $(".bindChange").dblclick(function(event) {
+        	event.stopPropagation();
+        });
+
         $( "#storyTheme,#epicTheme" ).autocomplete({
             minLength: 0,
             source: "../json/autocompletethemes/" + areaName,

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -1740,11 +1740,6 @@ $(document).ready(function () {
         	event.stopPropagation();
         });
 
-        //This avoids exiting edit mode if an element inside a theme, epic, story or task is double clicked.
-        $(".bindChange").dblclick(function(event) {
-        	event.stopPropagation();
-        });
-
         $( "#storyTheme,#epicTheme" ).autocomplete({
             minLength: 0,
             source: "../json/autocompletethemes/" + areaName,

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -1735,6 +1735,11 @@ $(document).ready(function () {
         	event.stopPropagation();
         });
 
+        //This avoids exiting edit mode if an element inside a theme, epic, story or task is double clicked.
+        $(".bindChange").dblclick(function(event) {
+        	event.stopPropagation();
+        });
+
         $( "#storyTheme,#epicTheme" ).autocomplete({
             minLength: 0,
             source: "../json/autocompletethemes/" + areaName,

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -1721,13 +1721,19 @@ $(document).ready(function () {
         $("a.cloneItem").click(function() {
             cloneItem($(this), false);
         });
+
         $("a.cloneItem-with-children").click(function() {
             cloneItem($(this), true);
         });
+
         $(".editTheme").dblclick(editTheme);
         $(".editEpic").dblclick(editEpic);
         $(".editStory").dblclick(editStory);
         $(".editTask").dblclick(editTask);
+        
+        $(".bindChange").dblclick(function(event) {
+        	event.stopPropagation();
+        });
 
         $( "#storyTheme,#epicTheme" ).autocomplete({
             minLength: 0,

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -1735,11 +1735,6 @@ $(document).ready(function () {
         	event.stopPropagation();
         });
 
-        //This avoids exiting edit mode if an element inside a theme, epic, story or task is double clicked.
-        $(".bindChange").dblclick(function(event) {
-        	event.stopPropagation();
-        });
-
         $( "#storyTheme,#epicTheme" ).autocomplete({
             minLength: 0,
             source: "../json/autocompletethemes/" + areaName,

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -1731,6 +1731,7 @@ $(document).ready(function () {
         $(".editStory").dblclick(editStory);
         $(".editTask").dblclick(editTask);
         
+        //This avoids exiting edit mode if an element inside a theme, epic, story or task is double clicked.
         $(".bindChange").dblclick(function(event) {
         	event.stopPropagation();
         });


### PR DESCRIPTION
It will no longer exit edit mode if you are double clicking within a
textarea or any other element in a task, story epic or theme.
I also did some minor CSS changes to make some things look better and tried to learn how to work with github, in Windows. That resulted in the 6 commits.
