### PR TITLE
Tweakings to the task title UI-element and the .taskInfo style.

### DIFF
--- a/src/main/webapp/resources/css/styles.css
+++ b/src/main/webapp/resources/css/styles.css
@@ -329,10 +329,7 @@ div#titleDivThemeEpic {
     font-size: 0.85em;
     display: inline;
     font-weight: bold;
-    margin-top: 0em;
-    margin-bottom: 0em;
-    margin-left: 0.2em;
-    margin-right: 0em;
+    margin: 0em 0em 0em 0.2em;
     vertical-align: middle;
 }
 

--- a/src/main/webapp/resources/css/styles.css
+++ b/src/main/webapp/resources/css/styles.css
@@ -329,6 +329,11 @@ div#titleDivThemeEpic {
     font-size: 0.85em;
     display: inline;
     font-weight: bold;
+    margin-top: 0em;
+    margin-bottom: 0em;
+    margin-left: 0.2em;
+    margin-right: 0em;
+    vertical-align: middle;
 }
 
 .calculatedTime {

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -1525,7 +1525,7 @@ $(document).ready(function () {
 	                        +'<p class="marginLeft typeMark">Task</p>'
 	                        //TYPE MARK END
 	                        +'<div class="taskTitle ' + currentChild.id + '">'
-	                        +'<p class="taskHeading">Title: </p><p class="taskInfo">'+ addLinksAndLineBreaks(truncate(currentChild.title, 190)) +'</p>'
+	                        +'<p class="taskInfo">'+ addLinksAndLineBreaks(truncate(currentChild.title, 190)) +'</p>'
 	                        +'</div>'
 	                        +'<textarea id="taskTitle' + currentChild.id + '" class="taskInfo bindChange taskTitle hidden-edit ' + currentChild.id + '" maxlength="500">' + currentChild.title + '</textarea>'
 	                        //TASKTITLE END


### PR DESCRIPTION
Removed the reduntant "Title: " prefix from task titles, which
brought unneccessary noise to the UI (at least for us with many
tasks).

Also adjusted the css for taskInfo, so that the task title/owner/etc
will line up nicely with the [Task] box.
