### PR TITLE
Fixes archived list border visibility

### DIFF
--- a/src/main/webapp/resources/css/styles.css
+++ b/src/main/webapp/resources/css/styles.css
@@ -34,6 +34,7 @@ h1 {
 
 #archived-list-container {
     border-top: 15px solid #555555;
+    display: none;
 }
 
 .story p {


### PR DESCRIPTION
Fixes that the border belonging to the archived list was visible by
default when entering a page, which it should not.
