### PR TITLE
Fixed bug for double-clicking on archived items

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>backlogtool</artifactId>
     <name>backlog-tool</name>
     <packaging>war</packaging>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <description>
         <![CDATA[A tool for managing backlogs]]>
     </description>

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -219,7 +219,9 @@ $(document).ready(function () {
             $(".editEpic").unbind("dblclick");
             $(".editStory").unbind("dblclick");
             $(".editTask").unbind("dblclick");
-            enableEdits();
+            if (!disableEditsBoolean) {
+                enableEdits();
+            }
         }
     });
 


### PR DESCRIPTION
Fixed a bug where it was possible to go into edit mode on archived items
without being logged in.
