### PR TITLE
Disable doubleclick on edit

### DIFF
--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -984,6 +984,18 @@ $(document).ready(function () {
         var id = event.data.id;
         editingItems.remove({id:id});
         $("."+id).toggleClass('hidden-edit');
+
+        //Re-activate double click
+        var li = $("li#"+id);
+        if (li.hasClass("task")) {
+            li.dblclick(editTask);
+        } else if (li.hasClass("story")) {
+            li.dblclick(editStory);
+        } else if (li.hasClass("epic")) {
+            li.dblclick(editEpic);
+        } else if (li.hasClass("theme")) {
+            li.dblclick(editTask);
+        }       
         updateWhenItemsClosed();
     };
 
@@ -991,11 +1003,7 @@ $(document).ready(function () {
      * Cancel current editing of parents/children.
      */
     var bulkCancel = function() {            
-        for(var j = 0; j < editingItems.length; j++) {
-            var id = editingItems[j].id;
-            $("."+id).toggleClass('hidden-edit');
-            editingItems.remove({id:id});
-        }
+        editingItems = new Array();
         updateWhenItemsClosed();
     };
 
@@ -1054,6 +1062,7 @@ $(document).ready(function () {
             story = getChild(storyId);
         }
         if (isGoingIntoEdit(storyId)) {
+            $("li#"+storyId).unbind("dblclick"); //Only the cancel button closes again
             editingItems.push({id:storyId, type:"story"});
             removeGroupMember();
             $('button.'+storyId).button();
@@ -1146,6 +1155,8 @@ $(document).ready(function () {
         } else {
             storyId = event.data.storyId;
         }
+        var li = $('#'+storyId);
+        
         //Creates a new story and sets all updated values
         var story = new Object();
         story.id = eval(storyId);
@@ -1199,8 +1210,6 @@ $(document).ready(function () {
             	$('.story-attr1-2').find('p.story-attr1.' + storyId).empty().append(getAttrImage(updatedStory.storyAttr1)).append(getNameIfExists(updatedStory.storyAttr1));
             	$('.story-attr1-2').find('p.story-attr2.' + storyId).empty().append(getAttrImage(updatedStory.storyAttr2)).append(getNameIfExists(updatedStory.storyAttr2));
             	$('.story-attr3').find('p.story-attr3.' + storyId).empty().append(getAttrImage(updatedStory.storyAttr3)).append(getNameIfExists(updatedStory.storyAttr3));
-            	
-            	var li = $('#'+storyId);
 
             	if (view == "story-task") {
             	    //If Story was moved,
@@ -1237,6 +1246,7 @@ $(document).ready(function () {
                 alert(error);
             }
         });
+        li.dblclick(editStory);
     };
 
     /**
@@ -1256,6 +1266,7 @@ $(document).ready(function () {
         else {
             taskId = event.data.taskId;
         }
+        var li = $('#'+taskId);
 
         //Creates a new task and sets all updated values
         var task = new Object();
@@ -1296,6 +1307,7 @@ $(document).ready(function () {
                 alert(error);
             }
         });
+        li.dblclick(editTask);
     };
 
     var editTask = function(event) {
@@ -1308,6 +1320,7 @@ $(document).ready(function () {
         }
         var task = getChild(taskId);
         if (isGoingIntoEdit(taskId)) {
+            $("li#"+taskId).unbind("dblclick"); //Only the cancel button closes again
             editingItems.push({id:taskId, type:"task"});
             removeGroupMember();
             $('button.'+taskId).button();
@@ -1345,6 +1358,7 @@ $(document).ready(function () {
         else {
             epicId = event.data.epicId;
         }
+        var li = $('#'+epicId);
 
         //Creates a new epic and sets all updated values
         var epic = new Object();
@@ -1375,8 +1389,6 @@ $(document).ready(function () {
                 if (extendedDescriptions.indexOf('truncate'+epicId) != -1) {
                     $('a.truncate'+epicId, descriptionParagraph.parent()).click();
                 }
-
-            	var li = $('#'+epicId);
 
             	if (view == "epic-story") {
             	    //If epic was moved,
@@ -1413,6 +1425,7 @@ $(document).ready(function () {
                 alert(error);
             }
         });
+        li.dblclick(editEpic);
     };
 
     var editEpic = function(event) {
@@ -1430,6 +1443,7 @@ $(document).ready(function () {
         }
 
         if (isGoingIntoEdit(epicId)) {
+            $("li#"+epicId).unbind("dblclick"); //Only the cancel button closes again
             editingItems.push({id:epicId, type:"epic"});
             removeGroupMember();
 
@@ -1473,6 +1487,7 @@ $(document).ready(function () {
         else {
             themeId = event.data.themeId;
         }
+        var li = $('#'+themeId);
 
         //Creates a new epic and sets all updated values
         var theme = new Object();
@@ -1502,8 +1517,6 @@ $(document).ready(function () {
                     $('a.truncate'+themeId, descriptionParagraph.parent()).click();
                 }
 
-            	var li = $('#'+themeId);
-
             	//if Story was moved from or to archive
             	if (getParent(themeId).archived != updatedTheme.archived) {
             		//Checks if this story is in list-container or in archived.list-container and moves it.
@@ -1529,6 +1542,7 @@ $(document).ready(function () {
                 alert(error);
             }
         });
+        li.dblclick(editTheme);
     };
 
     var editTheme = function(event) {
@@ -1544,7 +1558,7 @@ $(document).ready(function () {
             theme = getChild(themeId);
         }
         if (isGoingIntoEdit(themeId)) {
-
+            $("li#"+themeId).unbind("dblclick"); //Only the cancel button closes again
             editingItems.push({id:themeId, type:"theme"});
             removeGroupMember();
 

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -994,7 +994,7 @@ $(document).ready(function () {
         } else if (li.hasClass("epic")) {
             li.dblclick(editEpic);
         } else if (li.hasClass("theme")) {
-            li.dblclick(editTask);
+            li.dblclick(editTheme);
         }       
         updateWhenItemsClosed();
     };


### PR DESCRIPTION
It is no longer possible to double click on an story to close it again. This forces the user to make an active choice whether to save or cancel the changes.

fixes sonyxperiadev/BacklogTool#45
