### PR TITLE
Allowing editors to move stories between areas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>backlogtool</artifactId>
     <name>backlog-tool</name>
     <packaging>war</packaging>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
     <description>
         <![CDATA[A tool for managing backlogs]]>
     </description>

--- a/src/main/java/com/sonymobile/backlogtool/AttributeOption.java
+++ b/src/main/java/com/sonymobile/backlogtool/AttributeOption.java
@@ -60,6 +60,15 @@ public class AttributeOption {
         this.compareValue = compareValue;
     }
 
+    public AttributeOption copy() {
+        AttributeOption copy = new AttributeOption();
+        copy.name = name;
+        copy.icon = icon;
+        copy.color = color;
+        copy.iconEnabled = iconEnabled;
+        return copy;
+    } 
+
     public String getName() {
         return StringEscapeUtils.escapeHtml(name);
     }

--- a/src/main/java/com/sonymobile/backlogtool/BacklogType.java
+++ b/src/main/java/com/sonymobile/backlogtool/BacklogType.java
@@ -1,0 +1,33 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2013 Sony Mobile Communications AB. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonymobile.backlogtool;
+
+/**
+ * Enum for backlog types.
+ *
+ * @author Fredrik Persson &lt;fredrik6.persson@sonymobile.com&gt;
+ */
+public enum BacklogType {
+    TASK, STORY, EPIC, THEME
+} 

--- a/src/main/java/com/sonymobile/backlogtool/HomeController.java
+++ b/src/main/java/com/sonymobile/backlogtool/HomeController.java
@@ -217,9 +217,43 @@ public class HomeController {
     public ModelAndView storytask(Locale locale, Model model, @PathVariable String areaName) {
         Area area = getArea(areaName);
 
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String username = auth.getName();
+
+        List<String> adminAreas = null;
+        Session session = sessionFactory.openSession();
+        Transaction tx = null;
+        try {
+            tx = session.beginTransaction();
+
+            User currentUser = (User) session.get(User.class, username);
+
+            Query allAreasQuery = session.createQuery("from Area order by name");
+            List<Area> allAreas = Util.castList(Area.class, allAreasQuery.list());
+
+            adminAreas = new ArrayList<String>();
+            for (Area currentArea : allAreas) {
+                if (!areaName.equals(currentArea.getName()) &&
+                        ((currentUser != null && currentUser.isMasterAdmin()) 
+                                || currentArea.isAdmin(username))) {
+                    adminAreas.add(currentArea.getName());
+                }
+            }
+            tx.commit();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            if (tx != null) {
+                tx.rollback();
+            }
+        } finally {
+            session.close();
+        }
+
         ModelAndView view = new ModelAndView();
         view.addObject("isLoggedIn", isLoggedIn());
         view.addObject("area", area);
+        view.addObject("adminAreas", adminAreas); 
         view.addObject("disableEdits", isDisableEdits(areaName));
         view.addObject("view", "story-task");
         view.addObject("version", version.getVersion());

--- a/src/main/java/com/sonymobile/backlogtool/JSONController.java
+++ b/src/main/java/com/sonymobile/backlogtool/JSONController.java
@@ -30,6 +30,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator; 
 
 import javax.servlet.ServletContext;
 
@@ -37,7 +40,6 @@ import org.apache.commons.lang.StringEscapeUtils;
 import org.codehaus.jackson.JsonGenerationException;
 import org.codehaus.jackson.map.JsonMappingException;
 import org.codehaus.jackson.map.ObjectMapper;
-import org.hibernate.Hibernate;
 import org.hibernate.Query;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -61,6 +63,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+
+import com.sonymobile.backlogtool.permission.User;
 
 
 /**
@@ -1443,6 +1447,197 @@ public class JSONController {
         pushContext.push(areaName);
         return true;
     }
+
+    /**
+     * Used when moving stories between areas.
+     * @param areaName area to move from
+     * @param storyIds ids of the stories to move
+     * @param newAreaName target area
+     * @return true if everything was ok
+     */
+    @PreAuthorize("hasPermission(#areaName, 'isEditor')")
+    @RequestMapping(value="/moveToArea/{areaName}", method = RequestMethod.POST)
+    @Transactional
+    public @ResponseBody boolean moveToArea(@PathVariable String areaName,
+            @RequestBody int[] storyIds, @RequestParam String newAreaName) {
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String username = auth.getName();
+
+        Session session = sessionFactory.openSession();
+        Transaction tx = null;
+        try {
+            tx = session.beginTransaction();
+
+            Area newArea = (Area) session.get(Area.class, newAreaName);
+            User user = (User) session.get(User.class, username);
+
+            //Check that the user has rights for the new area as well
+            if ((newArea != null && (newArea.isAdmin(username) || newArea.isEditor(username)))
+                    || (user != null && user.isMasterAdmin())) {
+                List<Story> stories = new ArrayList<Story>(); 
+
+                //Get all the stories to move
+                for (int id : storyIds) {
+                    Query storyQuery = session.createQuery("from Story where area.name like ? and id=?");
+                    storyQuery.setParameter(0, areaName);
+                    storyQuery.setParameter(1, id);
+                    Story story = (Story) storyQuery.uniqueResult();
+                    stories.add(story);
+                }
+
+                Collections.sort(stories, new Comparator<Story>() {
+                    @Override
+                    public int compare(Story o1, Story o2) {
+                        return o1.getPrio() - o2.getPrio();
+                    }
+                });
+
+                for (Story story : stories) {
+                    story.setArea(newArea);
+
+                    //Change all story attribute options
+                    AttributeOption newOpt1 = getAttrAfterMove(story.getStoryAttr1(), newArea.getStoryAttr1().getOptions(), session);
+                    AttributeOption newOpt2 = getAttrAfterMove(story.getStoryAttr2(), newArea.getStoryAttr2().getOptions(), session);
+                    AttributeOption newOpt3 = getAttrAfterMove(story.getStoryAttr3(), newArea.getStoryAttr3().getOptions(), session);
+                    story.setStoryAttr1(newOpt1);
+                    story.setStoryAttr2(newOpt2);
+                    story.setStoryAttr3(newOpt3);
+
+                    //Change all task attribute options
+                    for (Task task : story.getChildren()) {
+                        AttributeOption taskOpt1 = getAttrAfterMove(task.getTaskAttr1(), newArea.getTaskAttr1().getOptions(), session);
+                        task.setTaskAttr1(taskOpt1);
+                    }
+
+                    //Set new rank
+                    int newPrio = Util.getNextPrio(BacklogType.STORY, newArea, session);
+                    story.setPrio(newPrio);
+
+                    //Handle move of theme and epic
+                    if (story.getEpic() != null && story.getTheme() != null) {
+                        //Both theme and epic exists.
+                        //Firstly, look for a matching theme
+                        Theme newTheme = getThemeAfterMove(story, newArea, session);
+                        story.setTheme(newTheme);
+
+                        //Look for a matching epic
+                        Epic newEpic = null;
+                        boolean foundMatch = false;
+                        for (Epic epic : newTheme.getChildren()) {
+                            if (epic.getTitle().equals(story.getEpic().getTitle())) {
+                                newEpic = epic;
+                                foundMatch = true;
+                                break;
+                            } 
+                        }
+                        if (!foundMatch) {
+                            //Create new epic in the theme.
+                            newEpic = story.getEpic().copy(false);
+                            newEpic.setArea(newArea);
+
+                            //Set correct prioInTheme and prio
+                            int prioInTheme = newTheme.getChildren().size() + 1;
+                            newEpic.setPrioInTheme(prioInTheme);
+
+                            int prio = Util.getNextPrio(BacklogType.EPIC, newArea, session);
+                            newEpic.setPrio(prio);
+                            session.save(newEpic);
+                        }
+                        story.getEpic().getChildren().remove(story);
+                        story.setEpic(newEpic);
+                        newEpic.getChildren().add(story);
+                        newEpic.setTheme(newTheme);
+
+                    } else if (story.getTheme() != null) {
+                        Theme newTheme = getThemeAfterMove(story, newArea, session);
+                        story.setTheme(newTheme);
+                    } else if (story.getEpic() != null) {
+                        Query epicQuery1 = session.createQuery("from Epic where area like ? and title like ?");
+                        epicQuery1.setParameter(0, newArea);
+                        epicQuery1.setParameter(1, story.getEpic().getTitle());
+                        Epic newEpic = (Epic) epicQuery1.uniqueResult();
+                        if (newEpic == null) {
+                            //Create new epic
+                            newEpic = story.getEpic().copy(false);
+                            newEpic.setArea(newArea);
+
+                            //Set correct prio
+                            int prio = Util.getNextPrio(BacklogType.EPIC, newArea, session);
+                            newEpic.setPrio(prio);
+                            session.save(newEpic);
+                        }
+                        story.getEpic().getChildren().remove(story);
+                        story.setEpic(newEpic);
+                        newEpic.getChildren().add(story);
+                        story.setTheme(newEpic.getTheme());
+                    }
+                }
+            }
+            tx.commit();
+        } catch (Exception e) {
+            e.printStackTrace();
+            if (tx != null) {
+                tx.rollback();
+            }
+        } finally {
+            session.close();
+        }
+        return true;
+    }
+
+    /**
+     * Helper for moveToArea. Finds a matching attribute after moving a story to a new area.
+     * Creates a new attribute if no match was found.
+     * @param currentOption the selected option in the old area
+     * @param targetOptions the available options in the new area
+     * @param session hibernate session
+     * @return matched attribute (or new attribute if no match)
+     */
+    private AttributeOption getAttrAfterMove(AttributeOption currentOption,
+            Set<AttributeOption> targetOptions, Session session) {
+        if (currentOption != null) {
+            for (AttributeOption newOption : targetOptions) {
+                if (newOption.getName().equals(currentOption.getName())) {
+                    return newOption;
+                }
+            }
+            //No matching attribute found; copy the attribute.
+            AttributeOption newOption = currentOption.copy();
+            Set<AttributeOption> attributeOptions = targetOptions;
+            newOption.setCompareValue(attributeOptions.size() + 1);
+            session.save(newOption);
+            attributeOptions.add(newOption);
+            return newOption;
+        }
+        return null;
+    }
+
+    /**
+     * Helper for moveToArea. Finds a matching theme after moving a story to a new area.
+     * Creates a new theme if no match was found.
+     * @param storyToMove the story thatäs being moved
+     * @param newArea target area
+     * @param session hibernate session
+     * @return matched theme (or new attribute if no match)
+     */
+    private Theme getThemeAfterMove(Story storyToMove, Area newArea, Session session) {
+        Query themeQuery = session.createQuery("from Theme where area like ? and title like ?");
+        themeQuery.setParameter(0, newArea);
+        themeQuery.setParameter(1, storyToMove.getTitle());
+        Theme newTheme = (Theme) themeQuery.uniqueResult();
+        if (newTheme == null) {
+            //Create new theme
+            newTheme = storyToMove.getTheme().copy(false);
+            newTheme.setArea(newArea);
+
+            //Set prio for theme
+            int prio = Util.getNextPrio(BacklogType.THEME, newArea, session);
+            newTheme.setPrio(prio);
+            session.save(newTheme);
+        }
+        return newTheme;
+    } 
 
     /**
      * Used when creating an area

--- a/src/main/java/com/sonymobile/backlogtool/Util.java
+++ b/src/main/java/com/sonymobile/backlogtool/Util.java
@@ -72,5 +72,44 @@ public final class Util {
         }
         q.setParameter(0, area);
         return q.list().size() + 1;
-    } 
+    }
+    
+    /**
+     * Rebuilds the rank ordering for a given backlog type
+     * (in case there are missing numbers).
+     * @param type backlog type to check rank on
+     * @param area the area to look in
+     * @param session hibernate session
+     * @throws RuntimeException if invalid type was specified
+     */
+    public static void rebuildRanks(BacklogType type, Area area, Session session) throws RuntimeException {
+        Query q = null;
+        int counter = 1;
+        switch (type) {
+        case STORY:
+            q=session.createQuery("from Story where area like ? and archived=false order by prio");
+            q.setParameter(0, area);
+            for (Story story : Util.castList(Story.class, q.list())) {
+                story.setPrio(counter++);
+            }
+            break;
+        case EPIC:
+            q=session.createQuery("from Epic where area like ? and archived=false order by prio");
+            q.setParameter(0, area);
+            for (Epic epic : Util.castList(Epic.class, q.list())) {
+                epic.setPrio(counter++);
+            }
+            break;
+        case THEME: 
+            q=session.createQuery("from Theme where area like ? and archived=false order by prio");
+            q.setParameter(0, area);
+            for (Theme theme : Util.castList(Theme.class, q.list())) {
+                theme.setPrio(counter++);
+            }
+            break;
+        default:
+            throw new RuntimeException("Invalid type specified");
+        }
+        
+    }
 }

--- a/src/main/java/com/sonymobile/backlogtool/Util.java
+++ b/src/main/java/com/sonymobile/backlogtool/Util.java
@@ -27,11 +27,15 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.hibernate.Query;
+import org.hibernate.Session; 
+
 
 /**
  * Utility class.
  *
  * @author David Pursehouse &lt;david.pursehouse@sonymobile.com&gt;
+ * @author Fredrik Persson &lt;fredrik6.persson@sonymobile.com&gt; 
  */
 public final class Util {
     public static <T> List<T> castList(Class<? extends T> clazz, Collection<?> c) {
@@ -41,4 +45,32 @@ public final class Util {
         }
         return r;
     }
+
+    /**
+     * Returns next available rank. Used when creating new backlog items that should be placed 
+     * at the bottom of the backlog.
+     * @param type backlog type to check rank on
+     * @param area the area to look in
+     * @param session hibernate session
+     * @return next available rank (the last1)
+     * @throws RuntimeException if invalid type was specified
+     */
+    public static int getNextPrio(BacklogType type, Area area, Session session) throws RuntimeException {
+        Query q = null;
+        switch (type) {
+        case STORY:
+            q=session.createQuery("from Story where area like ? and archived=false");
+            break;
+        case EPIC:
+            q=session.createQuery("from Epic where area like ? and archived=false");
+            break;
+        case THEME: 
+            q=session.createQuery("from Theme where area like ? and archived=false");
+            break;
+        default:
+            throw new RuntimeException("Invalid type specified");
+        }
+        q.setParameter(0, area);
+        return q.list().size() + 1;
+    } 
 }

--- a/src/main/webapp/WEB-INF/views/header.jsp
+++ b/src/main/webapp/WEB-INF/views/header.jsp
@@ -33,13 +33,19 @@ THE SOFTWARE.
 <button id="settings" data-dropdown="#settings-div" class="fff" title="More options">#</button>
 <div id="settings-div" class="dropdown dropdown-tip dropdown-relative">
     <ul class="dropdown-menu">
-        <li><a id="login-out" class="" href="../auth/logout"> <c:if
-                    test="${isLoggedIn == true}">LOG OUT</c:if> <c:if
-                    test="${isLoggedIn == false}">LOG IN</c:if>
-        </a></li>
-        <li><hr class="menu-divider">
-        <a id="expand-all" href="#" class="">EXPAND ALL</a></li>
-        <li><a id="collapse-all" class="">COLLAPSE ALL</a></li>
+        <li>
+            <a id="login-out" class="" href="../auth/logout">
+                <c:if test="${isLoggedIn == true}">LOG OUT</c:if>
+                <c:if test="${isLoggedIn == false}">LOG IN</c:if>
+            </a>
+        </li>
+        <li>
+            <hr class="menu-divider">
+            <a id="expand-all" href="#" class="">EXPAND ALL</a>
+        </li>
+        <li>
+            <a id="collapse-all" class="">COLLAPSE ALL</a>
+        </li>
         <li id="print-stories-li">
             <hr class="menu-divider">
             <a id="print-stories" title="Print selected stories">PRINT SELECTED</a>

--- a/src/main/webapp/WEB-INF/views/header.jsp
+++ b/src/main/webapp/WEB-INF/views/header.jsp
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
  -->
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %> 
 <h1>
     <a href="${pageContext.request.contextPath}/${area.name}">
         <p id="topic" class="textstyle inline">Backlog tool</p>
@@ -31,17 +32,35 @@ THE SOFTWARE.
 <br style="clear: both" />
 <button id="settings" data-dropdown="#settings-div" class="fff" title="More options">#</button>
 <div id="settings-div" class="dropdown dropdown-tip">
-        <ul class="dropdown-menu">
-        <li>
-            <a id="login-out" class="" href="../auth/logout">
-                <c:if test="${isLoggedIn == true}">LOG OUT</c:if>
-                <c:if test="${isLoggedIn == false}">LOG IN</c:if>
-            </a>
+    <ul class="dropdown-menu">
+        <li><a id="login-out" class="" href="../auth/logout"> <c:if
+                    test="${isLoggedIn == true}">LOG OUT</c:if> <c:if
+                    test="${isLoggedIn == false}">LOG IN</c:if>
+        </a></li>
+        <li><hr class="menu-divider">
+        <a id="expand-all" href="#" class="">EXPAND ALL</a></li>
+        <li><a id="collapse-all" class="">COLLAPSE ALL</a></li>
+        <li id="print-stories-li">
+            <hr class="menu-divider">
+            <a id="print-stories" title="Print selected stories">PRINT SELECTED</a>
         </li>
-        <li><a id="expand-all" href="#" class="">EXPAND ALL</a></li>
-        <li><a id="collapse-all" class="" >COLLAPSE ALL</a></li>
-        <li><a id="print-stories" class="" title="Print selected stories">PRINT SELECTED</a></li>
-        </ul>
+        
+        <c:if test="${isLoggedIn == true && adminAreas.size() > 0}">
+            <li id ="move-li">
+                <hr class="menu-divider">
+                <div id="move-div">
+                <p>Move selected to area...</p>
+                <select id="toArea" autocomplete="off" class="text ui-widget-content ui-corner-all">
+                    <option value=""></option>
+                    <c:forEach var="currentArea" items="${adminAreas}">
+                        <option value="${currentArea}">${currentArea}</option>
+                    </c:forEach>
+                </select>
+                </div>
+            </li>
+        </c:if>
+        
+    </ul>
 </div>
 <button title="Save all changes" id="save-all" class="save-button fff" disabled>#</button>
 <button title="Create a new story" id="create-parent" class="fff"></button>

--- a/src/main/webapp/resources/css/styles.css
+++ b/src/main/webapp/resources/css/styles.css
@@ -147,6 +147,15 @@ select#order-by {
     font-size: 10px;
 }
 
+#move-div {
+	margin-left: 15px;
+	margin-right: 13px;
+}
+
+#toArea {
+	width: 140px;
+}
+
 #topic,#topic-area {
     padding: 10px 0 10px 0;
 }
@@ -635,4 +644,9 @@ div.filter, div.order-by, div.showArchive {
 div#namechange-div {
 	margin-top: 105px;
 	margin-bottom: 40px;
+}
+
+hr.menu-divider {
+	margin-top: 3px;
+	margin-bottom: 3px;
 }

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -509,6 +509,14 @@ $(document).ready(function () {
         }
         createCookie("backlogtool-orderby", orderBy, 60);
     });
+    
+    $('#toArea').bind('change', function() {
+        var toArea = $("#toArea").val();
+        if (toArea != '') {
+            moveToArea();
+        }
+        $("#toArea").val(''); //Reset to default value
+    }); 
 
     var expandClick = function (e) {
         if ($(this).attr("class").indexOf("ui-icon-triangle-1-s") != -1) {
@@ -1569,6 +1577,56 @@ $(document).ready(function () {
     };
     
     /**
+     * Used when moving stories to another area.
+     */
+    var moveToArea = function() {
+        $('#settings').dropdown('hide');
+        var newArea = $("#toArea").val();
+        
+        var storiesToMove = new Array();
+        for (var i = 0; i < selectedItems.length; i++) {
+            if (selectedItems[i].type == "parent") {
+                storiesToMove.push(selectedItems[i].id);
+            }
+        }
+        if (storiesToMove.length > 0) {
+            var moveStoryDialog = $(document.createElement('div'));
+            $(moveStoryDialog).attr('title', 'Move stories to area');
+            $(moveStoryDialog).html('<p>Do you want to move the ' + storiesToMove.length
+                    + ' selected item(s) to ' + newArea + '?</p>');
+            $(moveStoryDialog).dialog({
+                resizable : false,
+                height : 180,
+                modal : true,
+                buttons : {
+                    "Move stories" : function() {
+                        $.ajax({
+                            url: "../json/moveToArea" + "/" + areaName + "?newAreaName="+newArea,
+                            type: 'POST',
+                            dataType: 'json',
+                            data: JSON.stringify(storiesToMove),
+                            contentType: "application/json; charset=utf-8",
+                            success: function (data) {
+                                reload();
+                            },
+                            error: function (request, status, error) {
+                                alert(error);
+                                reload();
+                            }
+                        });
+                        $(this).dialog("close");
+                    },
+                    Cancel : function() {
+                        $(this).dialog("close");
+                    }
+                }
+            });
+        } else {
+            alert("No stories selected!");
+        }
+    }; 
+
+    /**
      * Updates save all button and enable ranking etc, when the last editing item is going out of edit mode.
      */
     var updateWhenItemsClosed = function() {
@@ -2162,7 +2220,8 @@ $(document).ready(function () {
         $("#topic").text("BACKLOG TOOL / ");
         $("#topic-area").text(areaName);
     } else if (view == "epic-story") {
-        $("#print-stories").remove();
+        $("#print-stories-li").remove();
+        $("#move-li").remove();
         $( "#create-parent" ).button({ label: "CREATE EPIC" }).click(function() {
             createEpic();
         });
@@ -2170,7 +2229,8 @@ $(document).ready(function () {
         $("#topic").text("BACKLOG TOOL / ");
         $("#topic-area").text(areaName);
     } else if (view == "theme-epic") {
-        $("#print-stories").remove();
+        $("#print-stories-li").remove();
+        $("#move-li").remove();
         $( "#create-parent" ).button({ label: "CREATE THEME" }).click(function() {
             createTheme();
         });
@@ -2178,8 +2238,9 @@ $(document).ready(function () {
         $("#topic").text("BACKLOG TOOL / ");
         $("#topic-area").text(areaName);
     } else if (view == "home") {
-        $("#print-stories").remove();
+        $("#print-stories-li").remove();
         $("create-parent").remove();
+        $("#move-li").remove();
         $(".home-link").css("color", "#1c94c4");
         $("#topic-area").text("BACKLOG TOOL");
     }

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -1623,6 +1623,7 @@ $(document).ready(function () {
                             contentType: "application/json; charset=utf-8",
                             success: function (data) {
                                 reload();
+                                selectedItems = new Array();
                             },
                             error: function (request, status, error) {
                                 alert(error);

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -1638,7 +1638,18 @@ $(document).ready(function () {
                 }
             });
         } else {
-            alert("No stories selected!");
+            var noStoriesDialog = $(document.createElement('div'));
+            $(noStoriesDialog).attr('title', 'No stories selected');
+            $(noStoriesDialog).html('<p>Please select stories to move before using this option!</p>');
+            noStoriesDialog.dialog({
+                modal: true,
+                width: 325,
+                buttons: {
+                    Ok: function() {
+                        $( this ).dialog( "close" );
+                    }
+                }
+            });
         }
     }; 
 


### PR DESCRIPTION
Editors now have an option to move stories between areas through an alternative in the new options menu. 
If a dynamic attribute is missing in the target area, it will get copied to the new area.
