### PR TITLE
Fixed scrolling bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>backlogtool</artifactId>
     <name>backlog-tool</name>
     <packaging>war</packaging>
-    <version>1.1.4</version>
+    <version>1.1.5</version>
     <description>
         <![CDATA[A tool for managing backlogs]]>
     </description>

--- a/src/main/webapp/resources/css/styles.css
+++ b/src/main/webapp/resources/css/styles.css
@@ -31,7 +31,7 @@ html, body {
 }
 
 #main {
-	overflow:auto;
+	overflow:hidden;
 	padding-bottom: 20px;  /* must be same height as the footer */
 }
 

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -2348,6 +2348,8 @@ $(document).ready(function () {
         placeholder: "ui-state-highlight",
         opacity: 0.50,
         axis: 'y',
+        scroll: true,
+        scrollSpeed: 35,
         distance: 5,
         helper: function () {
             var pressed = $(".over");


### PR DESCRIPTION
Users can now scroll by moving a story to the top or bottom of the screen while sorting.

fixes sonyxperiadev/BacklogTool#73
