### PR TITLE
Fixed move of stories with statuses from series

### DIFF
--- a/src/main/java/com/sonymobile/backlogtool/AttributeOption.java
+++ b/src/main/java/com/sonymobile/backlogtool/AttributeOption.java
@@ -68,6 +68,7 @@ public class AttributeOption {
         copy.icon = icon;
         copy.color = color;
         copy.iconEnabled = iconEnabled;
+        copy.seriesIncrement = seriesIncrement;
         return copy;
     } 
 


### PR DESCRIPTION
Stories that are moved between areas now keep their status as part of a series after move. Before this change its status was considered to be a single element after move.
