### PR TITLE
Fix for #43, persisting the status of the Archived-checkbox on page refresh

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>backlogtool</artifactId>
     <name>backlog-tool</name>
     <packaging>war</packaging>
-    <version>1.1.6</version>
+    <version>1.1.7</version>
     <description>
         <![CDATA[A tool for managing backlogs]]>
     </description>

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -357,6 +357,7 @@ $(document).ready(function () {
         $("#order-by").val(sorting);
     }
     
+    // Load checkbox-status for the Archived-checkbox
     var dispArchived = readCookie("backlogtool-disparchived");
     if(dispArchived != null) {
     	$('#archived-checkbox').prop('checked', (dispArchived == "checked"));

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -211,7 +211,8 @@ $(document).ready(function () {
 
     $('#archived-checkbox').change(function () {
         $('#archived-list-container').toggle($('#archived-checkbox').is(":checked"));
-        if ($("#archived-checkbox").prop("checked")) {
+        var dispArchived = $("#archived-checkbox").prop("checked");
+        if (dispArchived) {
             $("#archived-list-container").empty();
             buildVisibleList(true);
 
@@ -224,6 +225,8 @@ $(document).ready(function () {
                 enableEdits();
             }
         }
+        var cookieStr = (dispArchived) ? "checked" : "unchecked";
+        createCookie("backlogtool-disparchived", cookieStr, 60);
     });
 
     /**
@@ -353,7 +356,12 @@ $(document).ready(function () {
     if (sorting != null) {
         $("#order-by").val(sorting);
     }
-
+    
+    var dispArchived = readCookie("backlogtool-disparchived");
+    if(dispArchived != null) {
+    	$('#archived-checkbox').prop('checked', (dispArchived == "checked"));
+    }
+    
     var readData = function readData() {
         $.ajax({
             url: "../json/read" + view + "/" + areaName + "?order=" + $("#order-by").val(),


### PR DESCRIPTION
The status of the checkbox is stored in a cookie, to persist page refreshes, in e.g. Chrome, and page switches
