### PR TITLE
Rendering in JSP instead of Javascript

### DIFF
--- a/src/main/java/com/sonymobile/backlogtool/Epic.java
+++ b/src/main/java/com/sonymobile/backlogtool/Epic.java
@@ -117,6 +117,15 @@ public class Epic {
         this.description = StringEscapeUtils.unescapeHtml(description);
     }
 
+    /**
+     * @return description where <a>-tags have been added around URLs
+     * and newline-chars have been replaced with <br />.
+     */
+    @JsonIgnore
+    public String getDescriptionWithLinksAndLineBreaks() {
+        return Util.textAsHtmlLinksAndLineBreaks(getDescription());
+    }
+
     public int getPrio() {
         return prio;
     }

--- a/src/main/java/com/sonymobile/backlogtool/HomeController.java
+++ b/src/main/java/com/sonymobile/backlogtool/HomeController.java
@@ -60,13 +60,12 @@ import org.springframework.web.servlet.ModelAndView;
 
 import com.sonymobile.backlogtool.permission.User;
 
-
 /**
  * Handles requests for the application web pages.
- *
+ * 
  * @author Fredrik Persson &lt;fredrik5.persson@sonymobile.com&gt;
  * @author Nicklas Nilsson &lt;nicklas4.persson@sonymobile.com&gt;
- *
+ * 
  */
 @Controller
 public class HomeController {
@@ -76,13 +75,15 @@ public class HomeController {
 
     @Autowired
     ServletContext context;
-    
+
     @Autowired
     ApplicationVersion version;
 
     @RequestMapping(value = "/", method = RequestMethod.GET)
-    public ModelAndView home(Locale locale, Model model, HttpServletResponse response) {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    public ModelAndView home(Locale locale, Model model,
+            HttpServletResponse response) {
+        Authentication auth = SecurityContextHolder.getContext()
+                .getAuthentication();
         String username = auth.getName();
 
         List<String> adminAreas = null;
@@ -95,8 +96,10 @@ public class HomeController {
 
             User currentUser = (User) session.get(User.class, username);
 
-            Query allAreasQuery = session.createQuery("from Area order by name");
-            List<Area> allAreas = Util.castList(Area.class, allAreasQuery.list());
+            Query allAreasQuery = session
+                    .createQuery("from Area order by name");
+            List<Area> allAreas = Util.castList(Area.class,
+                    allAreasQuery.list());
 
             adminAreas = new ArrayList<String>();
             nonAdminAreas = new ArrayList<String>();
@@ -120,8 +123,9 @@ public class HomeController {
             session.close();
         }
 
-        //Disables cache on this page so that the area list is refreshed every time.
-        response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+        // Disables cache on this page so that the area list is refreshed every time.
+        response.setHeader("Cache-Control",
+                "no-cache, no-store, must-revalidate");
 
         ModelAndView view = new ModelAndView("home");
         view.addObject("nonAdminAreas", nonAdminAreas);
@@ -130,35 +134,38 @@ public class HomeController {
         view.addObject("view", "home");
         view.addObject("version", version.getVersion());
         view.addObject("versionNoDots", version.getVersion().replace(".", ""));
-        view.addObject("loggedInUser", SecurityContextHolder.getContext().getAuthentication().getName());
+        view.addObject("loggedInUser", SecurityContextHolder.getContext()
+                .getAuthentication().getName());
         return view;
     }
 
     @PreAuthorize("hasPermission(#areaName, 'isAdmin')")
     @RequestMapping(value = "/areaedit/{areaName}", method = RequestMethod.GET)
-    public ModelAndView areaedit(Locale locale, Model model, @PathVariable String areaName)
-            throws JsonGenerationException, JsonMappingException, IOException {
+    public ModelAndView areaedit(Locale locale, Model model,
+            @PathVariable String areaName) throws JsonGenerationException,
+            JsonMappingException, IOException {
         Area area = Util.getArea(areaName, sessionFactory);
 
         File dir = new File(context.getRealPath("/resources/image"));
         String[] icons = dir.list();
-        
-        //Maps: SeriesID -> comparevalue -> attributeID
-        HashMap<Integer,HashMap<Integer,Integer>> seriesIds = new HashMap<Integer,HashMap<Integer,Integer>>();
+
+        // Maps: SeriesID -> comparevalue -> attributeID
+        HashMap<Integer, HashMap<Integer, Integer>> seriesIds = new HashMap<Integer, HashMap<Integer, Integer>>();
 
         ArrayList<Attribute> allAttributes = new ArrayList<Attribute>();
         allAttributes.add(area.getStoryAttr1());
         allAttributes.add(area.getStoryAttr2());
         allAttributes.add(area.getStoryAttr3());
         allAttributes.add(area.getTaskAttr1());
-        
+
         for (Attribute currentAttr : allAttributes) {
             Set<AttributeOption> options = currentAttr.getOptions();
             Set<AttributeOption> newOptions = groupSeries(options, seriesIds);
             currentAttr.setOptions(newOptions);
         }
 
-        String seriesIdsString = new ObjectMapper().writeValueAsString(seriesIds);
+        String seriesIdsString = new ObjectMapper()
+                .writeValueAsString(seriesIds);
 
         ModelAndView view = new ModelAndView("areaedit");
         view.addObject("isLoggedIn", isLoggedIn());
@@ -167,19 +174,24 @@ public class HomeController {
         view.addObject("icons", icons);
         view.addObject("version", version.getVersion());
         view.addObject("versionNoDots", version.getVersion().replace(".", ""));
-        view.addObject("loggedInUser", SecurityContextHolder.getContext().getAuthentication().getName());
+        view.addObject("loggedInUser", SecurityContextHolder.getContext()
+                .getAuthentication().getName());
         return view;
     }
 
     /**
      * Helper for areaedit. Groups attribute options in series.
-     * @param options the options to group
-     * @param seriesIds map where the series ids are mapped to another map where
-     *                  compare values are mapped to attribute ids.
+     * 
+     * @param options
+     *            the options to group
+     * @param seriesIds
+     *            map where the series ids are mapped to another map where
+     *            compare values are mapped to attribute ids.
      * @return Set of grouped attribute options
      */
-    private static Set<AttributeOption> groupSeries(Set<AttributeOption> options,
-            HashMap<Integer,HashMap<Integer,Integer>> seriesIds) {
+    private static Set<AttributeOption> groupSeries(
+            Set<AttributeOption> options,
+            HashMap<Integer, HashMap<Integer, Integer>> seriesIds) {
         Set<AttributeOption> newOptions = new LinkedHashSet<AttributeOption>();
         String lastName = null;
         String lastIcon = null;
@@ -189,23 +201,32 @@ public class HomeController {
         int lastSeriesEnd = -1;
         int lastSeriesId = -1;
         Integer lastSeriesIncrement = null;
-        HashMap<Integer,Integer> lastIds = new HashMap<Integer, Integer>();
+        HashMap<Integer, Integer> lastIds = new HashMap<Integer, Integer>();
         for (AttributeOption option : options) {
             Integer seriesIncrement = option.getSeriesIncrement();
-            if (seriesIncrement != null) { //If current is part of series.
-                if (lastSeriesIncrement!= null && seriesIncrement != null
+            if (seriesIncrement != null) { // If current is part of series.
+                if (lastSeriesIncrement != null
+                        && seriesIncrement != null
                         && Double.compare(lastSeriesIncrement, seriesIncrement) == 0
-                        && lastName != null && lastName.equals(option.getNameNoNumber())
-                        && lastIcon != null && lastIcon.equals(option.getIcon())
-                        && option.getNumber() == lastSeriesEnd+lastSeriesIncrement) { //If current series was same as last
+                        && lastName != null
+                        && lastName.equals(option.getNameNoNumber())
+                        && lastIcon != null
+                        && lastIcon.equals(option.getIcon())
+                        && option.getNumber() == lastSeriesEnd
+                                + lastSeriesIncrement) { // If current series
+                                                         // was same as last
                     lastSeriesEnd = option.getNumber();
-                } else { //Not same as last
-                    if (lastSeriesIncrement != null) { //If it's not the first series
-                        AttributeOptionSeries series = new AttributeOptionSeries(lastSeriesId, lastName, lastIcon, lastIconEnabled,
-                                lastCompareValue, lastSeriesStart, lastSeriesEnd, lastSeriesIncrement);
+                } else { // Not same as last
+                    if (lastSeriesIncrement != null) { // If it's not the first
+                                                       // series
+                        AttributeOptionSeries series = new AttributeOptionSeries(
+                                lastSeriesId, lastName, lastIcon,
+                                lastIconEnabled, lastCompareValue,
+                                lastSeriesStart, lastSeriesEnd,
+                                lastSeriesIncrement);
                         newOptions.add(series);
                     }
-                    
+
                     lastSeriesStart = option.getNumber();
                     lastSeriesEnd = option.getNumber();
                     lastCompareValue = option.getCompareValue();
@@ -216,21 +237,26 @@ public class HomeController {
                     lastIds = new HashMap<Integer, Integer>();
                 }
                 lastIds.put(option.getNumber(), option.getId());
-            } else { //Current is not part of a series                
-                if (lastSeriesIncrement != null) {//If current is not part of series, but last was
+            } else { // Current is not part of a series
+                if (lastSeriesIncrement != null) {// If current is not part of
+                                                  // series, but last was
                     seriesIds.put(lastSeriesId, lastIds);
-                    AttributeOptionSeries series = new AttributeOptionSeries(lastSeriesId, lastName, lastIcon, lastIconEnabled,
-                            lastCompareValue, lastSeriesStart, lastSeriesEnd, lastSeriesIncrement);
+                    AttributeOptionSeries series = new AttributeOptionSeries(
+                            lastSeriesId, lastName, lastIcon, lastIconEnabled,
+                            lastCompareValue, lastSeriesStart, lastSeriesEnd,
+                            lastSeriesIncrement);
                     newOptions.add(series);
-                } 
+                }
                 newOptions.add(option);
             }
             lastSeriesIncrement = seriesIncrement;
         }
-        if (lastSeriesIncrement != null) { //Last was a series
+        if (lastSeriesIncrement != null) { // Last was a series
             seriesIds.put(lastSeriesId, lastIds);
-            AttributeOptionSeries series = new AttributeOptionSeries(lastSeriesId, lastName, lastIcon, lastIconEnabled,
-                    lastCompareValue, lastSeriesStart, lastSeriesEnd, lastSeriesIncrement);
+            AttributeOptionSeries series = new AttributeOptionSeries(
+                    lastSeriesId, lastName, lastIcon, lastIconEnabled,
+                    lastCompareValue, lastSeriesStart, lastSeriesEnd,
+                    lastSeriesIncrement);
             newOptions.add(series);
         }
         return newOptions;
@@ -238,11 +264,14 @@ public class HomeController {
 
     /**
      * Returns a printer-friendly page for stories
-     * @param ids which stories to print
+     * 
+     * @param ids
+     *            which stories to print
      * @return page
      */
     @RequestMapping(value = "/print-stories/{areaName}", method = RequestMethod.GET)
-    public ModelAndView printStories(Locale locale, Model model, @RequestParam List<Integer> ids, @PathVariable String areaName) {
+    public ModelAndView printStories(Locale locale, Model model,
+            @RequestParam List<Integer> ids, @PathVariable String areaName) {
         List<Story> stories = null;
         Area area = null;
         Session session = sessionFactory.openSession();
@@ -260,9 +289,10 @@ public class HomeController {
             Hibernate.initialize(area.getStoryAttr2());
             Hibernate.initialize(area.getStoryAttr3());
 
-            Query storyQuery = session.createQuery("select distinct s from Story s " +
-                    "left join fetch s.children " +
-                    "where s.area like ? and s.id in (:ids)");
+            Query storyQuery = session
+                    .createQuery("select distinct s from Story s "
+                            + "left join fetch s.children "
+                            + "where s.area like ? and s.id in (:ids)");
             storyQuery.setParameter(0, area);
             storyQuery.setParameterList("ids", ids);
 
@@ -286,17 +316,21 @@ public class HomeController {
     }
 
     @RequestMapping(value = "/story-task/{areaName}", method = RequestMethod.GET)
-    public ModelAndView storytask(Locale locale, Model model, @PathVariable String areaName,
-            @CookieValue(value="backlogtool-orderby", defaultValue="prio", required = false) String order,
-            @RequestParam(required=false) Set<Integer> ids) {
+    public ModelAndView storytask(
+            Locale locale,
+            Model model,
+            @PathVariable String areaName,
+            @CookieValue(value = "backlogtool-orderby", defaultValue = "prio", required = false) String order,
+            @RequestParam(required = false, value="ids") Set<Integer> filterIds) {
 
         Area area = Util.getArea(areaName, sessionFactory);
 
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        Authentication auth = SecurityContextHolder.getContext()
+                .getAuthentication();
         String username = auth.getName();
 
-        List<Story> nonArchivedList = null;
-        List<String> adminAreas = null;
+        List<Story> nonArchivedStories = null;
+        Set<String> adminAreas = null;
         ModelAndView view = new ModelAndView();
 
         if (area == null) {
@@ -308,46 +342,40 @@ public class HomeController {
             try {
                 tx = session.beginTransaction();
 
-                User currentUser = (User) session.get(User.class, username);
+                //Get the areas that the user is admin for, which is used to
+                //populate the move-to-area select box. Exclude the current area, since
+                //it's no point of moving stories to the same area.
+                //Allow only admins to move since missing story attributes are created
+                //automatically.
+                adminAreas = getAdminAreaNames(session, username);
+                adminAreas.remove(area.getName());
 
-                Query allAreasQuery = session.createQuery("from Area order by name");
-                List<Area> allAreas = Util.castList(Area.class, allAreasQuery.list());
-
-                adminAreas = new ArrayList<String>();
-                for (Area currentArea : allAreas) {
-                    if (!areaName.equals(currentArea.getName()) &&
-                            ((currentUser != null && currentUser.isMasterAdmin()) 
-                                    || currentArea.isAdmin(username))) {
-                        adminAreas.add(currentArea.getName());
-                    }
-                }
                 String queryString = null;
                 if (order.contains("storyAttr")) {
-                    //If the user wants to sort by one of the custom created attributes, then the attributeOptions
-                    //needs to be sorted by their compareValues.
-                    queryString = "select distinct s from Story s " +
-                            "left join fetch s.children " +
-                            "left join fetch s." + order + " as attr " +
-                            "where s.area = ? " +
-                            "and s.archived = false " +
-                            "order by attr.compareValue";
-                } else if (order.equals("title") || order.equals("description") || order.equals("contributor")
-                        || order.equals("customer") || order.equals("contributorSite") || order.equals("customerSite")) {
-                    queryString = "select distinct s from Story s " +
-                            "left join fetch s.children " +
-                            "where s.area = ? " +
-                            "and s.archived = false " +
-                            "order by s." + order;
-                } else { //Fall back to sorting by prio
-                    queryString = "select distinct s from Story s " +
-                            "left join fetch s.children " +
-                            "where s.area = ? and " +
-                            "s.archived = false " +
-                            "order by s.prio";
+                    // If the user wants to sort by one of the custom created
+                    // attributes,
+                    // then the attributeOptions needs to be sorted by their
+                    // compareValues.
+                    queryString = "select distinct s from Story s "
+                            + "left join fetch s.children "
+                            + "left join fetch s." + order + " as attr "
+                            + "where s.area = ? " + "and s.archived = false "
+                            + "order by attr.compareValue";
+                } else if (order.matches("description|contributor" +
+                        "|customer|contributorSite|customerSite")) {
+                    queryString = "select distinct s from Story s "
+                            + "left join fetch s.children "
+                            + "where s.area = ? " + "and s.archived = false "
+                            + "order by s." + order;
+                } else { // Fall back to sorting by prio
+                    queryString = "select distinct s from Story s "
+                            + "left join fetch s.children "
+                            + "where s.area = ? and " + "s.archived = false "
+                            + "order by s.prio";
                 }
                 Query query = session.createQuery(queryString);
                 query.setParameter(0, area);
-                nonArchivedList = Util.castList(Story.class, query.list());
+                nonArchivedStories = Util.castList(Story.class, query.list());
 
                 tx.commit();
             } catch (Exception e) {
@@ -363,7 +391,8 @@ public class HomeController {
             Task placeholderTask = new Task();
             placeholderStory.setId(-1);
             placeholderTask.setId(-1);
-            placeholderTask.setStory(placeholderStory);//Makes sure task.story.id is -1 as well
+            //Prevents NPE from task.getStory().getId():
+            placeholderTask.setStory(placeholderStory);
 
             view.addObject("placeholderStory", placeholderStory);
             view.addObject("placeholderTask", placeholderTask);
@@ -371,23 +400,27 @@ public class HomeController {
             view.addObject("adminAreas", adminAreas);
             view.addObject("disableEdits", isDisableEdits(areaName));
             view.addObject("view", "story-task");
-            view.addObject("nonArchivedList", nonArchivedList);
-            view.addObject("ids", ids);
+            view.addObject("nonArchivedStories", nonArchivedStories);
+            view.addObject("filterIds", filterIds);
         }
         view.addObject("version", version.getVersion());
         view.addObject("versionNoDots", version.getVersion().replace(".", ""));
         view.addObject("isLoggedIn", isLoggedIn());
-        view.addObject("loggedInUser", SecurityContextHolder.getContext().getAuthentication().getName());
+        view.addObject("loggedInUser", SecurityContextHolder.getContext()
+                .getAuthentication().getName());
         return view;
     }
 
     @RequestMapping(value = "/epic-story/{areaName}", method = RequestMethod.GET)
-    public ModelAndView epicstory(Locale locale, Model model, @PathVariable String areaName,
-            @CookieValue(value="backlogtool-orderby", defaultValue="prio", required = false) String order,
-            @RequestParam(required=false) Set<Integer> ids) {
+    public ModelAndView epicstory(
+            Locale locale,
+            Model model,
+            @PathVariable String areaName,
+            @CookieValue(value = "backlogtool-orderby", defaultValue = "prio", required = false) String order,
+            @RequestParam(required = false, value="ids") Set<Integer> filterIds) {
 
         Area area = Util.getArea(areaName, sessionFactory);
-        List<Epic> nonArchivedList = null;
+        List<Epic> nonArchivedEpics = null;
 
         ModelAndView view = new ModelAndView();
 
@@ -402,23 +435,21 @@ public class HomeController {
                 tx = session.beginTransaction();
 
                 String queryString = null;
-                if (order.equals("title") || order.equals("description")) {
-                    queryString = "select distinct e from Epic e " +
-                            "left join fetch e.children " +
-                            "where e.area = ? and " +
-                            "e.archived=false " +
-                            "order by e." + order;
-                } else { //Fall back to sorting by prio
-                    queryString = "select distinct e from Epic e " +
-                            "left join fetch e.children " +
-                            "where e.area = ? and " +
-                            "e.archived = false " +
-                            "order by e.prio";
+                if (order.matches("title|description")) {
+                    queryString = "select distinct e from Epic e "
+                            + "left join fetch e.children "
+                            + "where e.area = ? and " + "e.archived=false "
+                            + "order by e." + order;
+                } else { // Fall back to sorting by prio
+                    queryString = "select distinct e from Epic e "
+                            + "left join fetch e.children "
+                            + "where e.area = ? and " + "e.archived = false "
+                            + "order by e.prio";
                 }
 
                 Query query = session.createQuery(queryString);
                 query.setParameter(0, area);
-                nonArchivedList = Util.castList(Epic.class, query.list());
+                nonArchivedEpics = Util.castList(Epic.class, query.list());
 
                 tx.commit();
             } catch (Exception e) {
@@ -434,12 +465,13 @@ public class HomeController {
             Story placeholderStory = new Story();
             placeholderEpic.setId(-1);
             placeholderStory.setId(-1);
-            placeholderStory.setEpic(placeholderEpic);//Makes sure story.epic.id is -1 as well
+            //Prevents NPE from story.getEpic().getId():
+            placeholderStory.setEpic(placeholderEpic);
 
             view.addObject("placeholderEpic", placeholderEpic);
             view.addObject("placeholderStory", placeholderStory);
-            view.addObject("nonArchivedList", nonArchivedList);
-            view.addObject("ids", ids);
+            view.addObject("nonArchivedEpics", nonArchivedEpics);
+            view.addObject("filterIds", filterIds);
             view.addObject("area", area);
             view.addObject("disableEdits", isDisableEdits(areaName));
             view.addObject("view", "epic-story");
@@ -447,17 +479,21 @@ public class HomeController {
         view.addObject("version", version.getVersion());
         view.addObject("versionNoDots", version.getVersion().replace(".", ""));
         view.addObject("isLoggedIn", isLoggedIn());
-        view.addObject("loggedInUser", SecurityContextHolder.getContext().getAuthentication().getName());
+        view.addObject("loggedInUser", SecurityContextHolder.getContext()
+                .getAuthentication().getName());
         return view;
     }
 
     @RequestMapping(value = "/theme-epic/{areaName}", method = RequestMethod.GET)
-    public ModelAndView themeepic(Locale locale, Model model, @PathVariable String areaName,
-            @CookieValue(value="backlogtool-orderby", defaultValue="prio", required = false) String order,
-            @RequestParam(required=false) Set<Integer> ids) {
+    public ModelAndView themeepic(
+            Locale locale,
+            Model model,
+            @PathVariable String areaName,
+            @CookieValue(value = "backlogtool-orderby", defaultValue = "prio", required = false) String order,
+            @RequestParam(required = false, value="ids") Set<Integer> filterIds) {
 
         Area area = Util.getArea(areaName, sessionFactory);
-        List<Theme> nonArchivedList = null;
+        List<Theme> nonArchivedThemes = null;
 
         ModelAndView view = new ModelAndView();
 
@@ -471,23 +507,21 @@ public class HomeController {
             try {
                 tx = session.beginTransaction();
                 String queryString = null;
-                if (order.equals("title") || order.equals("description")) {
-                    queryString = "select distinct t from Theme t " +
-                            "left join fetch t.children " +
-                            "where t.area = ? and " +
-                            "t.archived = false " +
-                            "order by t." + order;
-                } else { //Fall back to sorting by prio
-                    queryString = "select distinct t from Theme t " +
-                            "left join fetch t.children " +
-                            "where t.area = ? and " +
-                            "t.archived = false " +
-                            "order by t.prio";
+                if (order.matches("title||description")) {
+                    queryString = "select distinct t from Theme t "
+                            + "left join fetch t.children "
+                            + "where t.area = ? and " + "t.archived = false "
+                            + "order by t." + order;
+                } else { // Fall back to sorting by prio
+                    queryString = "select distinct t from Theme t "
+                            + "left join fetch t.children "
+                            + "where t.area = ? and " + "t.archived = false "
+                            + "order by t.prio";
                 }
                 Query query = session.createQuery(queryString);
                 query.setParameter(0, area);
 
-                nonArchivedList = Util.castList(Theme.class, query.list());
+                nonArchivedThemes = Util.castList(Theme.class, query.list());
 
                 tx.commit();
             } catch (Exception e) {
@@ -502,12 +536,13 @@ public class HomeController {
             Epic placeholderEpic = new Epic();
             placeholderTheme.setId(-1);
             placeholderEpic.setId(-1);
-            placeholderEpic.setTheme(placeholderTheme);//Makes sure epic.theme.id is -1 as well
+            //Prevents NPE from epic.getTheme().getId():
+            placeholderEpic.setTheme(placeholderTheme);
 
             view.addObject("placeholderTheme", placeholderTheme);
             view.addObject("placeholderEpic", placeholderEpic);
-            view.addObject("nonArchivedList", nonArchivedList);
-            view.addObject("ids", ids);
+            view.addObject("nonArchivedThemes", nonArchivedThemes);
+            view.addObject("filterIds", filterIds);
             view.addObject("area", area);
             view.addObject("disableEdits", isDisableEdits(areaName));
             view.addObject("view", "theme-epic");
@@ -515,19 +550,48 @@ public class HomeController {
         view.addObject("version", version.getVersion());
         view.addObject("versionNoDots", version.getVersion().replace(".", ""));
         view.addObject("isLoggedIn", isLoggedIn());
-        view.addObject("loggedInUser", SecurityContextHolder.getContext().getAuthentication().getName());
+        view.addObject("loggedInUser", SecurityContextHolder.getContext()
+                .getAuthentication().getName());
         return view;
     }
 
     /**
+     * Returns a sorted set (by name) of area names that the
+     * argument username is admin for.
+     * 
+     * @param session
+     *            hibernate session
+     * @param username
+     * @return sorted set of area names
+     */
+    private Set<String> getAdminAreaNames(Session session, String username) {
+        Set<String> adminAreas = new LinkedHashSet<String>();
+        User currentUser = (User) session.get(User.class, username);
+
+        Query allAreasQuery = session.createQuery("from Area order by name");
+        List<Area> allAreas = Util.castList(Area.class, allAreasQuery.list());
+
+        for (Area currentArea : allAreas) {
+            if ((currentUser != null && currentUser.isMasterAdmin())
+                    || currentArea.isAdmin(username)) {
+                adminAreas.add(currentArea.getName());
+            }
+        }
+        return adminAreas;
+    }
+
+    /**
      * Checks if the user is allowed to make edits to this specific area.
-     * @param areaName Area name to check
+     * 
+     * @param areaName
+     *            Area name to check
      * @return disableEdits true if edits shall be disabled
      */
     private boolean isDisableEdits(String areaName) {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        Authentication auth = SecurityContextHolder.getContext()
+                .getAuthentication();
         if (!isLoggedIn()) {
-            //Not logged in, edits must be disabled.
+            // Not logged in, edits must be disabled.
             return true;
         }
         String username = auth.getName();
@@ -541,7 +605,8 @@ public class HomeController {
             User currentUser = (User) session.get(User.class, username);
 
             Area area = (Area) session.get(Area.class, areaName);
-            if (area != null && (area.isAdmin(username) || area.isEditor(username))
+            if (area != null
+                    && (area.isAdmin(username) || area.isEditor(username))
                     || (currentUser != null && currentUser.isMasterAdmin())) {
                 disableEdits = false;
             }
@@ -558,8 +623,10 @@ public class HomeController {
     }
 
     private boolean isLoggedIn() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        GrantedAuthority anonymous = new SimpleGrantedAuthority("ROLE_ANONYMOUS");
+        Authentication auth = SecurityContextHolder.getContext()
+                .getAuthentication();
+        GrantedAuthority anonymous = new SimpleGrantedAuthority(
+                "ROLE_ANONYMOUS");
         return !auth.getAuthorities().contains(anonymous);
     }
 

--- a/src/main/java/com/sonymobile/backlogtool/HomeController.java
+++ b/src/main/java/com/sonymobile/backlogtool/HomeController.java
@@ -370,6 +370,12 @@ public class HomeController {
             session.close();
         }
 
+        Story placeholderStory = new Story();
+        Task placeholderTask = new Task();
+        placeholderStory.setId(-1);
+        placeholderTask.setId(-1);
+        placeholderTask.setStory(placeholderStory);//Makes sure task.story.id is -1 as well
+
         ModelAndView view = new ModelAndView();
         view.addObject("isLoggedIn", isLoggedIn());
         view.addObject("area", area);
@@ -381,6 +387,8 @@ public class HomeController {
         view.addObject("loggedInUser", SecurityContextHolder.getContext().getAuthentication().getName());
         view.addObject("nonArchivedList", nonArchivedList);
         view.addObject("ids", ids);
+        view.addObject("placeholderStory", placeholderStory);
+        view.addObject("placeholderTask", placeholderTask);
 
         if (area == null) {
             view.setViewName("area-noexist");

--- a/src/main/java/com/sonymobile/backlogtool/HomeController.java
+++ b/src/main/java/com/sonymobile/backlogtool/HomeController.java
@@ -436,6 +436,7 @@ public class HomeController {
             view.addObject("placeholderEpic", placeholderEpic);
             view.addObject("placeholderStory", placeholderStory);
             view.addObject("nonArchivedList", nonArchivedList);
+            view.addObject("ids", ids);
             view.addObject("area", area);
             view.addObject("disableEdits", isDisableEdits(areaName));
             view.addObject("view", "epic-story");
@@ -502,6 +503,7 @@ public class HomeController {
             view.addObject("placeholderTheme", placeholderTheme);
             view.addObject("placeholderEpic", placeholderEpic);
             view.addObject("nonArchivedList", nonArchivedList);
+            view.addObject("ids", ids);
             view.addObject("area", area);
             view.addObject("disableEdits", isDisableEdits(areaName));
             view.addObject("view", "theme-epic");

--- a/src/main/java/com/sonymobile/backlogtool/HomeController.java
+++ b/src/main/java/com/sonymobile/backlogtool/HomeController.java
@@ -321,7 +321,7 @@ public class HomeController {
             Model model,
             @PathVariable String areaName,
             @CookieValue(value = "backlogtool-orderby", defaultValue = "prio", required = false) String order,
-            @RequestParam(required = false, value="ids") Set<Integer> filterIds) {
+            @RequestParam(required = false, value = "ids") Set<Integer> filterIds) {
 
         Area area = Util.getArea(areaName, sessionFactory);
 
@@ -417,7 +417,7 @@ public class HomeController {
             Model model,
             @PathVariable String areaName,
             @CookieValue(value = "backlogtool-orderby", defaultValue = "prio", required = false) String order,
-            @RequestParam(required = false, value="ids") Set<Integer> filterIds) {
+            @RequestParam(required = false, value = "ids") Set<Integer> filterIds) {
 
         Area area = Util.getArea(areaName, sessionFactory);
         List<Epic> nonArchivedEpics = null;
@@ -490,7 +490,7 @@ public class HomeController {
             Model model,
             @PathVariable String areaName,
             @CookieValue(value = "backlogtool-orderby", defaultValue = "prio", required = false) String order,
-            @RequestParam(required = false, value="ids") Set<Integer> filterIds) {
+            @RequestParam(required = false, value = "ids") Set<Integer> filterIds) {
 
         Area area = Util.getArea(areaName, sessionFactory);
         List<Theme> nonArchivedThemes = null;

--- a/src/main/java/com/sonymobile/backlogtool/HomeController.java
+++ b/src/main/java/com/sonymobile/backlogtool/HomeController.java
@@ -287,7 +287,8 @@ public class HomeController {
 
     @RequestMapping(value = "/story-task/{areaName}", method = RequestMethod.GET)
     public ModelAndView storytask(Locale locale, Model model, @PathVariable String areaName,
-            @CookieValue("backlogtool-orderby") String order, @RequestParam(required=false) Set<Integer> ids) {
+            @CookieValue(value="backlogtool-orderby", defaultValue="prio", required = false) String order,
+            @RequestParam(required=false) Set<Integer> ids) {
 
         Area area = Util.getArea(areaName, sessionFactory);
 
@@ -328,20 +329,21 @@ public class HomeController {
                             "left join fetch s.children " +
                             "left join fetch s." + order + " as attr " +
                             "where s.area = ? " +
-                            "and s.archived=false " +
+                            "and s.archived = false " +
                             "order by attr.compareValue";
-                } else if (order.equals("prio")) {
-                    queryString = "select distinct s from Story s " +
-                            "left join fetch s.children " +
-                            "where s.area = ? and " +
-                            "s.archived=false " +
-                            "order by s.prio";
-                } else {
+                } else if (order.equals("title") || order.equals("description") || order.equals("contributor")
+                        || order.equals("customer") || order.equals("contributorSite") || order.equals("customerSite")) {
                     queryString = "select distinct s from Story s " +
                             "left join fetch s.children " +
                             "where s.area = ? " +
                             "and s.archived = false " +
                             "order by s." + order;
+                } else { //Fall back to sorting by prio
+                    queryString = "select distinct s from Story s " +
+                            "left join fetch s.children " +
+                            "where s.area = ? and " +
+                            "s.archived = false " +
+                            "order by s.prio";
                 }
                 Query query = session.createQuery(queryString);
                 query.setParameter(0, area);
@@ -381,7 +383,8 @@ public class HomeController {
 
     @RequestMapping(value = "/epic-story/{areaName}", method = RequestMethod.GET)
     public ModelAndView epicstory(Locale locale, Model model, @PathVariable String areaName,
-            @CookieValue("backlogtool-orderby") String order, @RequestParam(required=false) Set<Integer> ids) {
+            @CookieValue(value="backlogtool-orderby", defaultValue="prio", required = false) String order,
+            @RequestParam(required=false) Set<Integer> ids) {
 
         Area area = Util.getArea(areaName, sessionFactory);
         List<Epic> nonArchivedList = null;
@@ -399,18 +402,18 @@ public class HomeController {
                 tx = session.beginTransaction();
 
                 String queryString = null;
-                if (order.equals("prio")) {
-                    queryString = "select distinct e from Epic e " +
-                            "left join fetch e.children " +
-                            "where e.area = ? and " +
-                            "e.archived=false " +
-                            "order by e.prio";
-                } else {
+                if (order.equals("title") || order.equals("description")) {
                     queryString = "select distinct e from Epic e " +
                             "left join fetch e.children " +
                             "where e.area = ? and " +
                             "e.archived=false " +
                             "order by e." + order;
+                } else { //Fall back to sorting by prio
+                    queryString = "select distinct e from Epic e " +
+                            "left join fetch e.children " +
+                            "where e.area = ? and " +
+                            "e.archived = false " +
+                            "order by e.prio";
                 }
 
                 Query query = session.createQuery(queryString);
@@ -450,7 +453,8 @@ public class HomeController {
 
     @RequestMapping(value = "/theme-epic/{areaName}", method = RequestMethod.GET)
     public ModelAndView themeepic(Locale locale, Model model, @PathVariable String areaName,
-            @CookieValue("backlogtool-orderby") String order, @RequestParam(required=false) Set<Integer> ids) {
+            @CookieValue(value="backlogtool-orderby", defaultValue="prio", required = false) String order,
+            @RequestParam(required=false) Set<Integer> ids) {
 
         Area area = Util.getArea(areaName, sessionFactory);
         List<Theme> nonArchivedList = null;
@@ -467,18 +471,18 @@ public class HomeController {
             try {
                 tx = session.beginTransaction();
                 String queryString = null;
-                if (order.equals("prio")) {
-                    queryString = "select distinct t from Theme t " +
-                            "left join fetch t.children " +
-                            "where t.area = ? and " +
-                            "t.archived=false " +
-                            "order by t.prio";
-                } else {
+                if (order.equals("title") || order.equals("description")) {
                     queryString = "select distinct t from Theme t " +
                             "left join fetch t.children " +
                             "where t.area = ? and " +
                             "t.archived = false " +
                             "order by t." + order;
+                } else { //Fall back to sorting by prio
+                    queryString = "select distinct t from Theme t " +
+                            "left join fetch t.children " +
+                            "where t.area = ? and " +
+                            "t.archived = false " +
+                            "order by t.prio";
                 }
                 Query query = session.createQuery(queryString);
                 query.setParameter(0, area);

--- a/src/main/java/com/sonymobile/backlogtool/Story.java
+++ b/src/main/java/com/sonymobile/backlogtool/Story.java
@@ -177,6 +177,15 @@ public class Story {
     }
 
     /**
+     * @return description where <a>-tags have been added around URLs
+     * and newline-chars have been replaced with <br />.
+     */
+    @JsonIgnore
+    public String getDescriptionWithLinksAndLineBreaks() {
+        return Util.textAsHtmlLinksAndLineBreaks(getDescription());
+    }
+
+    /**
      * @param description the description to set
      */
     public void setDescription(String description) {

--- a/src/main/java/com/sonymobile/backlogtool/Task.java
+++ b/src/main/java/com/sonymobile/backlogtool/Task.java
@@ -102,6 +102,15 @@ public class Task {
     }
 
     /**
+     * @return title where <a>-tags have been added around URLs
+     * and newline-chars have been replaced with <br />.
+     */
+    @JsonIgnore
+    public String getTitleWithLinksAndLineBreaks() {
+        return Util.textAsHtmlLinksAndLineBreaks(getTitle());
+    }
+
+    /**
      * Sets the id for this task. The server uses this one.
      */
     public void setId(int id) {

--- a/src/main/java/com/sonymobile/backlogtool/Theme.java
+++ b/src/main/java/com/sonymobile/backlogtool/Theme.java
@@ -110,6 +110,15 @@ public class Theme {
         this.description = StringEscapeUtils.unescapeHtml(description);
     }
 
+    /**
+     * @return description where <a>-tags have been added around URLs
+     * and newline-chars have been replaced with <br />.
+     */
+    @JsonIgnore
+    public String getDescriptionWithLinksAndLineBreaks() {
+        return Util.textAsHtmlLinksAndLineBreaks(getDescription());
+    }
+
     public int getPrio() {
         return prio;
     }

--- a/src/main/java/com/sonymobile/backlogtool/Util.java
+++ b/src/main/java/com/sonymobile/backlogtool/Util.java
@@ -153,4 +153,13 @@ public final class Util {
         }
         return area;
     }
+
+    /**
+     * @return text where <a>-tags have been added around URLs
+     * and newline-chars have been replaced with <br />.
+     */
+    public static String textAsHtmlLinksAndLineBreaks(String text) {
+        return text.replaceAll("(?i)(http:\\/\\/[^\\s]+)", "<a href='$1'>$1</a>")
+                .replaceAll("\\n", "<br />");
+    }
 }

--- a/src/main/java/com/sonymobile/backlogtool/Util.java
+++ b/src/main/java/com/sonymobile/backlogtool/Util.java
@@ -159,6 +159,9 @@ public final class Util {
      * and newline-chars have been replaced with <br />.
      */
     public static String textAsHtmlLinksAndLineBreaks(String text) {
+        if (text == null) {
+            return "";
+        }
         return text.replaceAll("(?i)(http:\\/\\/[^\\s]+)", "<a href='$1'>$1</a>")
                 .replaceAll("\\n", "<br />");
     }

--- a/src/main/webapp/WEB-INF/views/epic-story.jsp
+++ b/src/main/webapp/WEB-INF/views/epic-story.jsp
@@ -69,8 +69,8 @@ THE SOFTWARE.
             <div id="list-container-div">
                 <ul class="parent-child-list" id="list-container">
 
-                    <c:forEach var="epic" items="${nonArchivedList}">
-                        <c:if test="${ids == null || ids.contains(epic.id)}">
+                    <c:forEach var="epic" items="${nonArchivedEpics}">
+                        <c:if test="${filterIds == null || filterIds.contains(epic.id)}">
                             <%@ include file="/WEB-INF/views/placeholders/epic.jsp" %>
                             <c:forEach var="story" items="${epic.children}">
                                 <%@ include file="/WEB-INF/views/placeholders/story.jsp" %>

--- a/src/main/webapp/WEB-INF/views/epic-story.jsp
+++ b/src/main/webapp/WEB-INF/views/epic-story.jsp
@@ -57,8 +57,28 @@ THE SOFTWARE.
         </div>
 
         <div id="main">
+            <div id="epic-placeholder" class="placeholder" >
+                <c:set var="epic" value="${placeholderEpic}"/>
+                <%@ include file="/WEB-INF/views/placeholders/epic.jsp"%>
+            </div>
+            <div id="story-placeholder" class="placeholder" >
+                <c:set var="story" value="${placeholderStory}"/>
+                <%@ include file="/WEB-INF/views/placeholders/story.jsp"%>
+            </div>
+
             <div id="list-container-div">
-                <ul class="parent-child-list" id="list-container"></ul>
+                <ul class="parent-child-list" id="list-container">
+
+                    <c:forEach var="epic" items="${nonArchivedList}">
+                        <c:if test="${ids == null || ids.contains(epic.id)}">
+                            <%@ include file="/WEB-INF/views/placeholders/epic.jsp" %>
+                            <c:forEach var="story" items="${epic.children}">
+                                <%@ include file="/WEB-INF/views/placeholders/story.jsp" %>
+                            </c:forEach>
+                        </c:if>
+                    </c:forEach>
+
+                </ul>
                 <ul class="parent-child-list" id="archived-list-container"></ul>
             </div>
         </div>

--- a/src/main/webapp/WEB-INF/views/placeholders/epic.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/epic.jsp
@@ -1,0 +1,67 @@
+<li class="epic ui-state-default editEpic <c:if test='${view.equals("epic-story")}'>parentLi</c:if><c:if test='${view.equals("theme-epic")}'>childLi</c:if>"
+    id="${epic.id}">
+    <div id="icons">
+        <c:if test='${view.equals("epic-story")}'>
+            <div title="Show stories"
+            class="icon 
+            <c:if test="${epic.children.size() > 0}">expand-icon ui-icon ui-icon-triangle-1-e</c:if>
+            ">
+    </div>
+    <a id="${epic.id}" title="Create new story"
+        class="icon createStory add-child-icon"></a> 
+    </c:if>
+    <a id="${epic.id}" title="Clone this epic excluding children" class="cloneItem epic">
+    <img src="../resources/image/page_white_copy.png"></a>
+    </div> 
+    <!-- TITLE FIELDS -->
+    <c:if test='${view.equals("epic-story")}'>
+        <div class="titles-theme-epic">
+    </c:if>
+    <c:if test='${view.equals("theme-epic")}'>
+        <div class="padding-left titles-theme-epic">
+    </c:if>
+        <!-- TYPE MARK START -->
+        <p class="typeMark">Epic ${epic.id}</p>
+        <!-- TYPE MARK END -->
+        <!-- THEME START -->
+        <c:if test='${view.equals("epic-story")}'>
+            <p class="theme ${epic.id}">${epic.themeTitle}</p>
+            <textarea placeholder="Theme" id="epicTheme${epic.id}"
+                class="bindChange theme hidden-edit ${epic.id}" rows="1"
+                maxlength="100">${epic.themeTitle}</textarea>
+        </c:if>
+        <!-- THEME END -->
+        <br style="clear: both" />
+        <!-- EPIC TITLE START -->
+        <p class="titleText ${epic.id}">${epic.title}</p>
+        <textarea placeholder="Title" id="epicTitle${epic.id}"
+            class="bindChange titleText hidden-edit title ${epic.id}"
+            rows="1" maxlength="100">${epic.title}</textarea>
+        <!-- EPIC TITLE END -->
+        <!-- EPIC DESCRIPTION START -->
+        <p class="description epic-description ${epic.id}">${epic.descriptionWithLinksAndLineBreaks}</p>
+        <textarea placeholder="Description"
+            id="epicDescription${epic.id}"
+            class="bindChange hidden-edit description ${epic.id}"
+            rows="2" maxlength="100000">${epic.description}</textarea>
+        <!-- EPIC DESCRIPTION END -->
+    </div>
+    <!-- TITLE FIELDS END --> 
+    <a id="${epic.id}" title="Remove epic"
+        class="icon deleteItem delete-icon"></a> 
+    <input type="checkbox" class="marginTopBig inline bindChange hidden-edit ${epic.id}"
+    id="archiveEpic${epic.id}" 
+    <c:if test='${epic.archived}'>checked="checked"</c:if>
+    >
+    <p class="title inline hidden-edit ${epic.id}">Archive epic</p>
+    </input><br>
+    <button class="save-button hidden-edit ${epic.id}" title="Save">Save</button>
+    <button class="cancelButton hidden-edit ${epic.id}" title="Cancel">Cancel</button>
+    <c:if test='${epic.archived}'>
+        <p class="title ${epic.id}">Archived</p>
+    </c:if>
+    <p class="description ${epic.id}">
+        <fmt:formatDate value="${epic.dateArchived}" pattern="yyyy-MM-dd" />
+    </p>
+    <br style="clear: both" />
+</li>

--- a/src/main/webapp/WEB-INF/views/placeholders/epic.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/epic.jsp
@@ -1,4 +1,4 @@
-<li class="epic ui-state-default editEpic <c:if test='${view.equals("epic-story")}'>parentLi</c:if><c:if test='${view.equals("theme-epic")}'>childLi</c:if>"
+<li class="epic ui-state-default editEpic <c:if test='${view.equals("epic-story")}'>parentLi</c:if><c:if test='${view.equals("theme-epic")}'>childLi ui-hidden</c:if>"
     id="${epic.id}">
     <div id="icons">
         <c:if test='${view.equals("epic-story")}'>

--- a/src/main/webapp/WEB-INF/views/placeholders/epic.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/epic.jsp
@@ -12,8 +12,9 @@
             <a id="${epic.id}" title="Create new story"
                 class="icon createStory add-child-icon"></a> 
         </c:if>
-    <a id="${epic.id}" title="Clone this epic excluding children" class="cloneItem epic">
-    <img src="../resources/image/page_white_copy.png"></a>
+        <a id="${epic.id}" title="Clone this epic excluding children" class="cloneItem epic">
+            <img src="../resources/image/page_white_copy.png">
+        </a>
     </div> 
     <!-- TITLE FIELDS -->
     <c:if test='${view.equals("epic-story")}'>
@@ -23,11 +24,15 @@
         <div class="padding-left titles-theme-epic">
     </c:if>
         <!-- TYPE MARK START -->
-        <p class="typeMark">Epic ${epic.id}</p>
+        <p class="typeMark">
+            Epic ${epic.id}
+        </p>
         <!-- TYPE MARK END -->
         <!-- THEME START -->
         <c:if test='${view.equals("epic-story")}'>
-            <p class="theme ${epic.id}">${epic.themeTitle}</p>
+            <p class="theme ${epic.id}">
+                ${epic.themeTitle}
+            </p>
             <textarea placeholder="Theme" id="epicTheme${epic.id}"
                 class="bindChange theme hidden-edit ${epic.id}" rows="1"
                 maxlength="100">${epic.themeTitle}</textarea>
@@ -35,7 +40,9 @@
         <!-- THEME END -->
         <br style="clear: both" />
         <!-- EPIC TITLE START -->
-        <p class="titleText ${epic.id}">${epic.title}</p>
+        <p class="titleText ${epic.id}">
+            ${epic.title}
+        </p>
         <textarea placeholder="Title" id="epicTitle${epic.id}"
             class="bindChange titleText hidden-edit title ${epic.id}"
             rows="1" maxlength="100">${epic.title}</textarea>
@@ -52,15 +59,21 @@
     <a id="${epic.id}" title="Remove epic"
         class="icon deleteItem delete-icon"></a> 
     <input type="checkbox" class="marginTopBig inline bindChange hidden-edit ${epic.id}"
-    id="archiveEpic${epic.id}" 
-    <c:if test='${epic.archived}'>checked="checked"</c:if>
+        id="archiveEpic${epic.id}" 
+        <c:if test='${epic.archived}'>
+            checked="checked"
+        </c:if>
     >
-    <p class="title inline hidden-edit ${epic.id}">Archive epic</p>
-    </input><br>
+    <p class="title inline hidden-edit ${epic.id}">
+        Archive epic
+    </p>
+    <br>
     <button class="save-button hidden-edit ${epic.id}" title="Save">Save</button>
     <button class="cancelButton hidden-edit ${epic.id}" title="Cancel">Cancel</button>
     <c:if test='${epic.archived}'>
-        <p class="title ${epic.id}">Archived</p>
+        <p class="title ${epic.id}">
+            Archived
+        </p>
     </c:if>
     <p class="description ${epic.id}">
         <fmt:formatDate value="${epic.dateArchived}" pattern="yyyy-MM-dd" />

--- a/src/main/webapp/WEB-INF/views/placeholders/epic.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/epic.jsp
@@ -4,12 +4,14 @@
         <c:if test='${view.equals("epic-story")}'>
             <div title="Show stories"
             class="icon 
-            <c:if test="${epic.children.size() > 0}">expand-icon ui-icon ui-icon-triangle-1-e</c:if>
+            <c:if test="${epic.children.size() > 0}">
+                expand-icon ui-icon ui-icon-triangle-1-e
+            </c:if>
             ">
-    </div>
-    <a id="${epic.id}" title="Create new story"
-        class="icon createStory add-child-icon"></a> 
-    </c:if>
+            </div>
+            <a id="${epic.id}" title="Create new story"
+                class="icon createStory add-child-icon"></a> 
+        </c:if>
     <a id="${epic.id}" title="Clone this epic excluding children" class="cloneItem epic">
     <img src="../resources/image/page_white_copy.png"></a>
     </div> 

--- a/src/main/webapp/WEB-INF/views/placeholders/story.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/story.jsp
@@ -1,0 +1,182 @@
+<li class="parentLi story ui-state-default editStory" id="${story.id}">
+    <div id="icons">
+        <div title="Show tasks"
+            class="icon <c:if test="${story.children.size() > 0}">expand-icon ui-icon ui-icon-triangle-1-e</c:if>"></div>
+        <a id="${story.id}" title="Create new task"
+            class="icon createTask add-child-icon"></a><br> 
+        <a id="${story.id}" title="Clone this story excluding tasks"
+            class="cloneItem story"> <img src="../resources/image/page_white_copy.png"></a> 
+        <a id="${story.id}" title="Clone this story including tasks"
+            class="cloneItem-with-children story"> <img src="../resources/image/page_white_stack.png"></a>
+    </div>
+    <!--  TITLE FIELDS -->
+    <div class="titles">
+        <!-- TYPE MARK START -->
+        <p class="typeMark">Story ${story.id}</p>
+        <!-- TYPE MARK END -->
+        <!-- THEME START -->
+        <p class="theme ${story.id}">${story.themeTitle}</p>
+        <textarea placeholder="Theme" id="theme${story.id}"
+            class="bindChange theme hidden-edit ${story.id}" rows="1"
+            maxlength="100">${story.themeTitle}</textarea>
+        <!-- THEME END -->
+        <!-- EPIC START -->
+        <p class="epic ${story.id}">${story.epicTitle}</p>
+        <textarea placeholder="Epic" id="epic${story.id}"
+            class="bindChange epic hidden-edit ${story.id}" rows="1"
+            maxlength="100">${story.epicTitle}</textarea>
+        <!-- EPIC END -->
+        <br style="clear: both" />
+        <!-- STORY TITLE START -->
+        <p class="titleText ${story.id}">${story.title}</p>
+        <textarea placeholder="Title" id="title${story.id}"
+            class="bindChange titleText hidden-edit title ${story.id}"
+            rows="1" maxlength="100">${story.title}</textarea>
+        <!-- STORY TITLE END -->
+        <!-- STORYDESCRIPTION START -->
+        <p class="description story-description ${story.id}">${story.descriptionWithLinksAndLineBreaks}</p>
+        <textarea placeholder="Description" id="description${story.id}"
+            class="bindChange hidden-edit description ${story.id}"
+            rows="2" maxlength="100000">${story.description}</textarea>
+        <!-- STORYDESCRIPTION END -->
+    </div>
+    <!-- TITLE FIELDS END -->
+    <!-- STAKEHOLDER DIV START -->
+    <div class="stakeholders">
+        <!-- CUSTOMER FIELD START -->
+        <p class="title">Customer</p>
+        <p class="customerSite ${story.id}">
+            <c:if test='${story.customerSite != null && !story.customerSite.equals("NONE")}'>
+                <img
+                    src="../resources/css/ui-lightness/images/${story.customerSite}.png"
+                    title="${story.customerSite}"
+                    alt="${story.customerSite}" />
+            </c:if>
+        </p>
+        <p class="${story.id} customer description">${story.customer}&nbsp;</p><!-- &nbsp; Forces p-tag to have a height of one line -->
+        <select id="customerSite${story.id}"
+            class="bindChange customerSite hidden-edit ${story.id} text ui-widget-content ui-corner-all">
+            <option value="NONE"></option>
+            <option value="Beijing">Beijing</option>
+            <option value="Tokyo">Tokyo</option>
+            <option value="Lund">Lund</option>
+        </select> <input placeholder="Department" id="customer${story.id}"
+            class="bindChange customer hidden-edit ${story.id} text ui-widget-content ui-corner-all"
+            maxlength="50" value="${story.customer}"></input>
+        <!-- CUSTOMER FIELD END -->
+        <!-- CONTRIBUTOR FIELD START -->
+        <p class="title">Contributor</p>
+        <p id="${story.id}" class="contributorSite ${story.id}">
+            <c:if test='${story.contributorSite != null && !story.contributorSite.equals("NONE")}'>
+                <img
+                    src="../resources/css/ui-lightness/images/${story.contributorSite}.png"
+                    title="${story.contributorSite}"
+                    alt="${story.contributorSite}" />
+            </c:if>
+        </p>
+        <p class="${story.id} contributor description">${story.contributor}&nbsp;</p><!-- &nbsp; Forces p-tag to have a height of one line -->
+        <select id="contributorSite${story.id}"
+            class="bindChange contributorSite hidden-edit ${story.id} text ui-widget-content ui-corner-all">
+            <option value="NONE"></option>
+            <option value="Beijing">Beijing</option>
+            <option value="Tokyo">Tokyo</option>
+            <option value="Lund">Lund</option>
+        </select> <input placeholder="Department" id="contributor${story.id}"
+            class="bindChange contributor hidden-edit ${story.id} text ui-widget-content ui-corner-all"
+            maxlength="50" value="${story.contributor}"></input>
+        <!-- CONTRIBUTOR FIELD END -->
+    </div>
+    <!-- STAKEHOLDER DIV END -->
+    <!-- TIME FIELDS START -->
+    <div class="times">
+        <p class="title">Deadline</p>
+        <p class="deadline description ${story.id}">
+            <fmt:formatDate value="${story.deadline}"
+                pattern="yyyy-MM-dd" />
+        </p>
+        <input id="deadline${story.id}" type="text"
+            class="bindChange deadline hidden-edit ${story.id} text ui-widget-content ui-corner-all">
+        <p class="title">Added</p>
+        <p class="added description ${story.id}">
+            <fmt:formatDate value="${story.added}" pattern="yyyy-MM-dd" />
+        </p>
+        <input id="added${story.id}" type="text"
+            class="bindChange added hidden-edit ${story.id} text ui-widget-content ui-corner-all">
+    </div>
+    <!-- TIME FIELDS END -->
+    <!-- ATTR1 AND ATTR2 DIV START -->
+    <div class="story-attr1-2">
+        <!-- ATTR1 FIELD START -->
+        <p class="title">${area.storyAttr1.name}</p>
+        <p class="description story-attr1 ${story.id}">
+            <c:if
+                test='${story.storyAttr1 != null && story.storyAttr1.iconEnabled}'>
+                <img src="../resources/image/${story.storyAttr1.icon}"
+                    title="${story.storyAttr1.name}" /> ${story.storyAttr1.name}</c:if>
+        </p>
+        <select id="storyAttr1${story.id}"
+            class="bindChange story-attr1 hidden-edit ${story.id} text ui-widget-content ui-corner-all">
+            <option value=""></option>
+            <c:forEach var="option" items="${area.storyAttr1.options}">
+                <option value="${option.id}">${option.name}</option>
+            </c:forEach>
+        </select>
+        <!-- ATTR1 FIELD END -->
+        <!-- ATTR2 FIELD START -->
+        <p class="title">${area.storyAttr2.name}</p>
+        <p class="description story-attr2 ${story.id}">
+            <c:if
+                test='${story.storyAttr2 != null && story.storyAttr2.iconEnabled}'>
+                <img src="../resources/image/${story.storyAttr2.icon}"
+                    title="${story.storyAttr2.name}" /> ${story.storyAttr2.name}</c:if>
+        </p>
+        <select id="storyAttr2${story.id}"
+            class="bindChange story-attr2 hidden-edit ${story.id} text ui-widget-content ui-corner-all">
+            <option value=""></option>
+            <c:forEach var="option" items="${area.storyAttr2.options}">
+                <option value="${option.id}">${option.name}</option>
+            </c:forEach>
+        </select>
+        <!-- ATTR2 FIELD END -->
+    </div>
+    <!-- ATTR1 AND ATTR2 DIV END -->
+    <!-- ATTR3 DIV START -->
+    <div class="story-attr3">
+        <p class="title">${area.storyAttr3.name}</p>
+        <p class="description story-attr3 ${story.id}">
+            <c:if
+                test='${story.storyAttr3 != null && story.storyAttr3.iconEnabled}'>
+                <img src="../resources/image/${story.storyAttr3.icon}"
+                    title="${story.storyAttr3.name}" /> ${story.storyAttr3.name}</c:if>
+        </p>
+        <select id="storyAttr3${story.id}"
+            class="bindChange story-attr3 hidden-edit ${story.id} text ui-widget-content ui-corner-all">
+            <option value=""></option>
+            <c:forEach var="option" items="${area.storyAttr3.options}">
+                <option value="${option.id}">${option.name}</option>
+            </c:forEach>
+        </select> <input type="checkbox"
+            class="inline bindChange hidden-edit ${story.id}"
+            id="archiveStory${story.id}"
+            <c:if test='${story.archived}'>checked="checked"</c:if>>
+        <p class="title inline hidden-edit ${story.id}">Archive
+            story</p>
+        </input>
+        <button
+            class="inline marginTop save-button hidden-edit ${story.id}"
+            title="Save">Save</button>
+        <button
+            class="inline marginTop cancelButton hidden-edit ${story.id}"
+            title="Cancel">Cancel</button>
+        <c:if test='${story.archived}'>
+            <p class="title ${story.id}">Archived</p>
+        </c:if>
+        <p class="description ${story.id}">
+            <fmt:formatDate value="${story.dateArchived}"
+                pattern="yyyy-MM-dd" />
+        </p>
+    </div>
+    <!-- ATTR3 FIELD END -->
+    <a id="${story.id}" title="Remove story"
+        class="icon deleteItem delete-icon"></a> <br style="clear: both" />
+</li>

--- a/src/main/webapp/WEB-INF/views/placeholders/story.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/story.jsp
@@ -1,4 +1,4 @@
-<li class="story ui-state-default editStory <c:if test='${view.equals("story-task")}'>parentLi</c:if><c:if test='${view.equals("epic-story")}'>childLi</c:if>" 
+<li class="story ui-state-default editStory <c:if test='${view.equals("story-task")}'>parentLi</c:if><c:if test='${view.equals("epic-story")}'>childLi ui-hidden</c:if>" 
     id="${story.id}">
     <div id="icons">
         <c:if test='${view.equals("story-task")}'>

--- a/src/main/webapp/WEB-INF/views/placeholders/story.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/story.jsp
@@ -3,7 +3,11 @@
     <div id="icons">
         <c:if test='${view.equals("story-task")}'>
             <div title="Show tasks"
-                class="icon <c:if test="${story.children.size() > 0}">expand-icon ui-icon ui-icon-triangle-1-e</c:if>"></div>
+                class="icon 
+                <c:if test="${story.children.size() > 0}">
+                    expand-icon ui-icon ui-icon-triangle-1-e
+                </c:if>">
+            </div>
             <a id="${story.id}" title="Create new task"
                 class="icon createTask add-child-icon"></a><br> 
         </c:if>
@@ -120,8 +124,9 @@
         <p class="description story-attr1 ${story.id}">
             <c:if test='${story.storyAttr1 != null && story.storyAttr1.iconEnabled}'>
                 <img src="../resources/image/${story.storyAttr1.icon}"
-                    title="${story.storyAttr1.name}" /> ${story.storyAttr1.name}
+                    title="${story.storyAttr1.name}" /> 
             </c:if>
+            ${story.storyAttr1.name}
         </p>
         <select id="storyAttr1${story.id}"
             class="bindChange story-attr1 hidden-edit ${story.id} text ui-widget-content ui-corner-all">
@@ -136,8 +141,9 @@
         <p class="description story-attr2 ${story.id}">
             <c:if test='${story.storyAttr2 != null && story.storyAttr2.iconEnabled}'>
                 <img src="../resources/image/${story.storyAttr2.icon}"
-                    title="${story.storyAttr2.name}" /> ${story.storyAttr2.name}
+                    title="${story.storyAttr2.name}" /> 
              </c:if>
+             ${story.storyAttr2.name}
         </p>
         <select id="storyAttr2${story.id}"
             class="bindChange story-attr2 hidden-edit ${story.id} text ui-widget-content ui-corner-all">
@@ -155,8 +161,9 @@
         <p class="description story-attr3 ${story.id}">
             <c:if test='${story.storyAttr3 != null && story.storyAttr3.iconEnabled}'>
                 <img src="../resources/image/${story.storyAttr3.icon}"
-                    title="${story.storyAttr3.name}" /> ${story.storyAttr3.name}
+                    title="${story.storyAttr3.name}" /> 
             </c:if>
+            ${story.storyAttr3.name}
         </p>
         <select id="storyAttr3${story.id}"
             class="bindChange story-attr3 hidden-edit ${story.id} text ui-widget-content ui-corner-all">

--- a/src/main/webapp/WEB-INF/views/placeholders/story.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/story.jsp
@@ -9,10 +9,13 @@
                 </c:if>">
             </div>
             <a id="${story.id}" title="Create new task"
-                class="icon createTask add-child-icon"></a><br> 
+                class="icon createTask add-child-icon"></a>
+            <br> 
         </c:if>
         <a id="${story.id}" title="Clone this story excluding tasks"
-            class="cloneItem story"> <img src="../resources/image/page_white_copy.png"></a> 
+            class="cloneItem story"> 
+            <img src="../resources/image/page_white_copy.png">
+        </a> 
         <c:if test='${view.equals("story-task")}'>
             <a id="${story.id}" title="Clone this story including tasks"
                 class="cloneItem-with-children story"> <img src="../resources/image/page_white_stack.png"></a>
@@ -26,29 +29,39 @@
         <div class="padding-left titles-epic-story">
     </c:if>
         <!-- TYPE MARK START -->
-        <p class="typeMark">Story ${story.id}</p>
+        <p class="typeMark">
+            Story ${story.id}
+        </p>
         <!-- TYPE MARK END -->
         <!-- THEME START -->
-        <p class="theme ${story.id}">${story.themeTitle}</p>
+        <p class="theme ${story.id}">
+            ${story.themeTitle}
+        </p>
         <textarea placeholder="Theme" id="theme${story.id}"
             class="bindChange theme hidden-edit ${story.id}" rows="1"
             maxlength="100">${story.themeTitle}</textarea>
         <!-- THEME END -->
         <!-- EPIC START -->
-        <p class="epic ${story.id}">${story.epicTitle}</p>
+        <p class="epic ${story.id}">
+            ${story.epicTitle}
+        </p>
         <textarea placeholder="Epic" id="epic${story.id}"
             class="bindChange epic hidden-edit ${story.id}" rows="1"
             maxlength="100">${story.epicTitle}</textarea>
         <!-- EPIC END -->
         <br style="clear: both" />
         <!-- STORY TITLE START -->
-        <p class="titleText ${story.id}">${story.title}</p>
+        <p class="titleText ${story.id}">
+            ${story.title}
+        </p>
         <textarea placeholder="Title" id="title${story.id}"
             class="bindChange titleText hidden-edit title ${story.id}"
             rows="1" maxlength="100">${story.title}</textarea>
         <!-- STORY TITLE END -->
         <!-- STORYDESCRIPTION START -->
-        <p class="description story-description ${story.id}">${story.descriptionWithLinksAndLineBreaks}</p>
+        <p class="description story-description ${story.id}">
+            ${story.descriptionWithLinksAndLineBreaks}
+        </p>
         <textarea placeholder="Description" id="description${story.id}"
             class="bindChange hidden-edit description ${story.id}"
             rows="2" maxlength="100000">${story.description}</textarea>
@@ -58,7 +71,9 @@
     <!-- STAKEHOLDER DIV START -->
     <div class="stakeholders">
         <!-- CUSTOMER FIELD START -->
-        <p class="title">Customer</p>
+        <p class="title">
+            Customer
+        </p>
         <p class="customerSite ${story.id}">
             <c:if test='${story.customerSite != null && !story.customerSite.equals("NONE")}'>
                 <img
@@ -67,19 +82,24 @@
                     alt="${story.customerSite}" />
             </c:if>
         </p>
-        <p class="${story.id} customer description">${story.customer}&nbsp;</p><!-- &nbsp; Forces p-tag to have a height of one line -->
+        <p class="${story.id} customer description">
+            ${story.customer}&nbsp;<!-- &nbsp; Forces p-tag to have a height of one line -->
+        </p>
         <select id="customerSite${story.id}"
             class="bindChange customerSite hidden-edit ${story.id} text ui-widget-content ui-corner-all">
             <option value="NONE"></option>
             <option value="Beijing">Beijing</option>
             <option value="Tokyo">Tokyo</option>
             <option value="Lund">Lund</option>
-        </select> <input placeholder="Department" id="customer${story.id}"
+        </select> 
+        <input placeholder="Department" id="customer${story.id}"
             class="bindChange customer hidden-edit ${story.id} text ui-widget-content ui-corner-all"
             maxlength="50" value="${story.customer}"></input>
         <!-- CUSTOMER FIELD END -->
         <!-- CONTRIBUTOR FIELD START -->
-        <p class="title">Contributor</p>
+        <p class="title">
+            Contributor
+        </p>
         <p id="${story.id}" class="contributorSite ${story.id}">
             <c:if test='${story.contributorSite != null && !story.contributorSite.equals("NONE")}'>
                 <img
@@ -95,7 +115,8 @@
             <option value="Beijing">Beijing</option>
             <option value="Tokyo">Tokyo</option>
             <option value="Lund">Lund</option>
-        </select> <input placeholder="Department" id="contributor${story.id}"
+        </select> 
+        <input placeholder="Department" id="contributor${story.id}"
             class="bindChange contributor hidden-edit ${story.id} text ui-widget-content ui-corner-all"
             maxlength="50" value="${story.contributor}"></input>
         <!-- CONTRIBUTOR FIELD END -->
@@ -103,7 +124,9 @@
     <!-- STAKEHOLDER DIV END -->
     <!-- TIME FIELDS START -->
     <div class="times">
-        <p class="title">Deadline</p>
+        <p class="title">
+            Deadline
+        </p>
         <p class="deadline description ${story.id}">
             <fmt:formatDate value="${story.deadline}" pattern="yyyy-MM-dd" />
         </p>
@@ -137,7 +160,9 @@
         </select>
         <!-- ATTR1 FIELD END -->
         <!-- ATTR2 FIELD START -->
-        <p class="title">${area.storyAttr2.name}</p>
+        <p class="title">
+            ${area.storyAttr2.name}
+        </p>
         <p class="description story-attr2 ${story.id}">
             <c:if test='${story.storyAttr2 != null && story.storyAttr2.iconEnabled}'>
                 <img src="../resources/image/${story.storyAttr2.icon}"
@@ -171,13 +196,17 @@
             <c:forEach var="option" items="${area.storyAttr3.options}">
                 <option value="${option.id}">${option.name}</option>
             </c:forEach>
-        </select> <input type="checkbox"
+        </select> 
+        <input type="checkbox"
             class="inline bindChange hidden-edit ${story.id}"
             id="archiveStory${story.id}"
-            <c:if test='${story.archived}'>checked="checked"</c:if>>
-        <p class="title inline hidden-edit ${story.id}">Archive
-            story</p>
-        </input>
+            <c:if test='${story.archived}'>
+                checked="checked"
+            </c:if>
+        >
+        <p class="title inline hidden-edit ${story.id}">
+            Archive story
+        </p>
         <button
             class="inline marginTop save-button hidden-edit ${story.id}"
             title="Save">Save</button>
@@ -193,5 +222,6 @@
     </div>
     <!-- ATTR3 FIELD END -->
     <a id="${story.id}" title="Remove story"
-        class="icon deleteItem delete-icon"></a> <br style="clear: both" />
+        class="icon deleteItem delete-icon"></a> 
+    <br style="clear: both" />
 </li>

--- a/src/main/webapp/WEB-INF/views/placeholders/story.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/story.jsp
@@ -109,8 +109,7 @@
         <!-- ATTR1 FIELD START -->
         <p class="title">${area.storyAttr1.name}</p>
         <p class="description story-attr1 ${story.id}">
-            <c:if
-                test='${story.storyAttr1 != null && story.storyAttr1.iconEnabled}'>
+            <c:if test='${story.storyAttr1 != null && story.storyAttr1.iconEnabled}'>
                 <img src="../resources/image/${story.storyAttr1.icon}"
                     title="${story.storyAttr1.name}" /> ${story.storyAttr1.name}</c:if>
         </p>
@@ -125,8 +124,7 @@
         <!-- ATTR2 FIELD START -->
         <p class="title">${area.storyAttr2.name}</p>
         <p class="description story-attr2 ${story.id}">
-            <c:if
-                test='${story.storyAttr2 != null && story.storyAttr2.iconEnabled}'>
+            <c:if test='${story.storyAttr2 != null && story.storyAttr2.iconEnabled}'>
                 <img src="../resources/image/${story.storyAttr2.icon}"
                     title="${story.storyAttr2.name}" /> ${story.storyAttr2.name}</c:if>
         </p>
@@ -144,8 +142,7 @@
     <div class="story-attr3">
         <p class="title">${area.storyAttr3.name}</p>
         <p class="description story-attr3 ${story.id}">
-            <c:if
-                test='${story.storyAttr3 != null && story.storyAttr3.iconEnabled}'>
+            <c:if test='${story.storyAttr3 != null && story.storyAttr3.iconEnabled}'>
                 <img src="../resources/image/${story.storyAttr3.icon}"
                     title="${story.storyAttr3.name}" /> ${story.storyAttr3.name}</c:if>
         </p>

--- a/src/main/webapp/WEB-INF/views/placeholders/story.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/story.jsp
@@ -120,7 +120,8 @@
         <p class="description story-attr1 ${story.id}">
             <c:if test='${story.storyAttr1 != null && story.storyAttr1.iconEnabled}'>
                 <img src="../resources/image/${story.storyAttr1.icon}"
-                    title="${story.storyAttr1.name}" /> ${story.storyAttr1.name}</c:if>
+                    title="${story.storyAttr1.name}" /> ${story.storyAttr1.name}
+            </c:if>
         </p>
         <select id="storyAttr1${story.id}"
             class="bindChange story-attr1 hidden-edit ${story.id} text ui-widget-content ui-corner-all">
@@ -135,7 +136,8 @@
         <p class="description story-attr2 ${story.id}">
             <c:if test='${story.storyAttr2 != null && story.storyAttr2.iconEnabled}'>
                 <img src="../resources/image/${story.storyAttr2.icon}"
-                    title="${story.storyAttr2.name}" /> ${story.storyAttr2.name}</c:if>
+                    title="${story.storyAttr2.name}" /> ${story.storyAttr2.name}
+             </c:if>
         </p>
         <select id="storyAttr2${story.id}"
             class="bindChange story-attr2 hidden-edit ${story.id} text ui-widget-content ui-corner-all">
@@ -153,7 +155,8 @@
         <p class="description story-attr3 ${story.id}">
             <c:if test='${story.storyAttr3 != null && story.storyAttr3.iconEnabled}'>
                 <img src="../resources/image/${story.storyAttr3.icon}"
-                    title="${story.storyAttr3.name}" /> ${story.storyAttr3.name}</c:if>
+                    title="${story.storyAttr3.name}" /> ${story.storyAttr3.name}
+            </c:if>
         </p>
         <select id="storyAttr3${story.id}"
             class="bindChange story-attr3 hidden-edit ${story.id} text ui-widget-content ui-corner-all">

--- a/src/main/webapp/WEB-INF/views/placeholders/story.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/story.jsp
@@ -1,16 +1,26 @@
-<li class="parentLi story ui-state-default editStory" id="${story.id}">
+<li class="story ui-state-default editStory <c:if test='${view.equals("story-task")}'>parentLi</c:if><c:if test='${view.equals("epic-story")}'>childLi</c:if>" 
+    id="${story.id}">
     <div id="icons">
-        <div title="Show tasks"
-            class="icon <c:if test="${story.children.size() > 0}">expand-icon ui-icon ui-icon-triangle-1-e</c:if>"></div>
-        <a id="${story.id}" title="Create new task"
-            class="icon createTask add-child-icon"></a><br> 
+        <c:if test='${view.equals("story-task")}'>
+            <div title="Show tasks"
+                class="icon <c:if test="${story.children.size() > 0}">expand-icon ui-icon ui-icon-triangle-1-e</c:if>"></div>
+            <a id="${story.id}" title="Create new task"
+                class="icon createTask add-child-icon"></a><br> 
+        </c:if>
         <a id="${story.id}" title="Clone this story excluding tasks"
             class="cloneItem story"> <img src="../resources/image/page_white_copy.png"></a> 
-        <a id="${story.id}" title="Clone this story including tasks"
-            class="cloneItem-with-children story"> <img src="../resources/image/page_white_stack.png"></a>
+        <c:if test='${view.equals("story-task")}'>
+            <a id="${story.id}" title="Clone this story including tasks"
+                class="cloneItem-with-children story"> <img src="../resources/image/page_white_stack.png"></a>
+        </c:if>
     </div>
     <!--  TITLE FIELDS -->
-    <div class="titles">
+    <c:if test='${view.equals("story-task")}'>
+        <div class="titles">
+    </c:if>
+    <c:if test='${view.equals("epic-story")}'>
+        <div class="padding-left titles-epic-story">
+    </c:if>
         <!-- TYPE MARK START -->
         <p class="typeMark">Story ${story.id}</p>
         <!-- TYPE MARK END -->
@@ -91,8 +101,7 @@
     <div class="times">
         <p class="title">Deadline</p>
         <p class="deadline description ${story.id}">
-            <fmt:formatDate value="${story.deadline}"
-                pattern="yyyy-MM-dd" />
+            <fmt:formatDate value="${story.deadline}" pattern="yyyy-MM-dd" />
         </p>
         <input id="deadline${story.id}" type="text"
             class="bindChange deadline hidden-edit ${story.id} text ui-widget-content ui-corner-all">
@@ -169,8 +178,7 @@
             <p class="title ${story.id}">Archived</p>
         </c:if>
         <p class="description ${story.id}">
-            <fmt:formatDate value="${story.dateArchived}"
-                pattern="yyyy-MM-dd" />
+            <fmt:formatDate value="${story.dateArchived}" pattern="yyyy-MM-dd" />
         </p>
     </div>
     <!-- ATTR3 FIELD END -->

--- a/src/main/webapp/WEB-INF/views/placeholders/task.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/task.jsp
@@ -25,8 +25,9 @@
         <p class="taskInfo ${task.id}">
             <c:if test='${task.taskAttr1 != null && task.taskAttr1.iconEnabled}'>
                 <img src="../resources/image/${task.taskAttr1.icon}"
-                    title="${task.taskAttr1.name}" /> ${task.taskAttr1.name}
+                    title="${task.taskAttr1.name}" /> 
             </c:if>
+            ${task.taskAttr1.name}
         </p>
     </div> 
     <select id="taskAttr1${task.id}"

--- a/src/main/webapp/WEB-INF/views/placeholders/task.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/task.jsp
@@ -1,4 +1,4 @@
-<li class="childLi task ui-state-default editTask" parentId="${task.story.id}" id="${task.id}">
+<li class="childLi task ui-state-default editTask ui-hidden" parentId="${task.story.id}" id="${task.id}">
     <!-- TASKTITLE START -->
     <!-- TYPE MARK START -->
     <p class="marginLeft typeMark">Task ${task.id}</p>

--- a/src/main/webapp/WEB-INF/views/placeholders/task.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/task.jsp
@@ -12,8 +12,12 @@
     <!-- TASKTITLE END -->
     <!-- TASKOWNER START -->
     <div class="taskOwner ${task.id}" id="taskOwner ${task.id}">
-        <p class="taskHeading">Owner:</p>
-        <p class="taskInfo">${task.owner}</p>
+        <p class="taskHeading">
+            Owner:
+        </p>
+        <p class="taskInfo">
+            ${task.owner}
+        </p>
     </div> 
     <textarea id="taskOwner${task.id}"
         class="taskInfo bindChange taskOwner hidden-edit ${task.id}"
@@ -21,7 +25,9 @@
     <!-- TASKOWNER END -->
     <!-- STATUS FIELD START -->
     <div class="taskStatus ${task.id}" id="taskTitle${task.id}">
-        <p class="taskHeading">${area.taskAttr1.name}:</p>
+        <p class="taskHeading">
+            ${area.taskAttr1.name}:
+        </p>
         <p class="taskInfo ${task.id}">
             <c:if test='${task.taskAttr1 != null && task.taskAttr1.iconEnabled}'>
                 <img src="../resources/image/${task.taskAttr1.icon}"
@@ -40,8 +46,12 @@
     <!-- STATUS FIELD END -->
     <!-- CALULATEDTIME START -->
     <div class="calculatedTime ${task.id}" id="calculatedTime${task.id}">
-        <p class="taskHeading">Estimated time:</p>
-        <p class="taskInfo">${task.calculatedTime}</p>
+        <p class="taskHeading">
+            Estimated time:
+        </p>
+        <p class="taskInfo">
+            ${task.calculatedTime}
+        </p>
     </div> 
     <select id="calculatedTime${task.id}"
         class="taskInfo bindChange calculatedTime hidden-edit ${task.id} text ui-widget-content ui-corner-all">

--- a/src/main/webapp/WEB-INF/views/placeholders/task.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/task.jsp
@@ -1,0 +1,57 @@
+<li class="childLi task ui-state-default editTask" parentId="${task.story.id}" id="${task.id}">
+    <!-- TASKTITLE START -->
+    <!-- TYPE MARK START -->
+    <p class="marginLeft typeMark">Task</p>
+    <!-- TYPE MARK END -->
+    <div class="taskTitle ${task.id}">
+        <p class="taskInfo">${task.titleWithLinksAndLineBreaks}</p>
+    </div> 
+    <textarea id="taskTitle${task.id}"
+        class="taskInfo bindChange taskTitle hidden-edit ${task.id}"
+        maxlength="500">${task.title}</textarea> 
+    <!-- TASKTITLE END -->
+    <!-- TASKOWNER START -->
+    <div class="taskOwner ${task.id}" id="taskOwner ${task.id}">
+        <p class="taskHeading">Owner:</p>
+        <p class="taskInfo">${task.owner}</p>
+    </div> 
+    <textarea id="taskOwner${task.id}"
+        class="taskInfo bindChange taskOwner hidden-edit ${task.id}"
+        maxlength="50">${task.owner}</textarea>
+    <!-- TASKOWNER END -->
+    <!-- STATUS FIELD START -->
+    <div class="taskStatus ${task.id}" id="taskTitle${task.id}">
+        <p class="taskHeading">${area.taskAttr1.name}:</p>
+        <p class="taskInfo ${task.id}">
+            <c:if test='${task.taskAttr1 != null && task.taskAttr1.iconEnabled}'>
+                <img src="../resources/image/${task.taskAttr1.icon}"
+                    title="${task.taskAttr1.name}" /> ${task.taskAttr1.name}
+            </c:if>
+        </p>
+    </div> 
+    <select id="taskAttr1${task.id}"
+        class="bindChange taskInfo taskStatus hidden-edit ${task.id} text ui-widget-content ui-corner-all">
+        <option value=""></option>
+        <c:forEach var="option" items="${area.taskAttr1.options}">
+            <option value="${option.id}">${option.name}</option>
+        </c:forEach>
+    </select>
+    <!-- STATUS FIELD END -->
+    <!-- CALULATEDTIME START -->
+    <div class="calculatedTime ${task.id}" id="calculatedTime${task.id}">
+        <p class="taskHeading">Estimated time:</p>
+        <p class="taskInfo">${task.calculatedTime}</p>
+    </div> 
+    <select id="calculatedTime${task.id}"
+        class="taskInfo bindChange calculatedTime hidden-edit ${task.id} text ui-widget-content ui-corner-all">
+        <option value="0.5">0.5</option>
+        <option value="1">1</option>
+        <option value="1.5">1.5</option>
+        <option value="2">2</option>
+    </select> 
+    <!-- CALCULATEDTIME END -->
+    <button class="save-button hidden-edit ${task.id}" title="Save">Save</button>
+    <button class="cancelButton hidden-edit ${task.id}" title="Cancel">Cancel</button>
+    <a id="${task.id}" title="Remove task" class="icon deleteItem delete-icon"></a> 
+    <br style="clear: both" />
+</li>

--- a/src/main/webapp/WEB-INF/views/placeholders/task.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/task.jsp
@@ -1,7 +1,7 @@
 <li class="childLi task ui-state-default editTask" parentId="${task.story.id}" id="${task.id}">
     <!-- TASKTITLE START -->
     <!-- TYPE MARK START -->
-    <p class="marginLeft typeMark">Task</p>
+    <p class="marginLeft typeMark">Task ${task.id}</p>
     <!-- TYPE MARK END -->
     <div class="taskTitle ${task.id}">
         <p class="taskInfo">${task.titleWithLinksAndLineBreaks}</p>

--- a/src/main/webapp/WEB-INF/views/placeholders/theme.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/theme.jsp
@@ -8,25 +8,33 @@
         ">
     </div>
     <a id="${theme.id}" title="Create new epic"
-        class="icon createEpic add-child-icon"></a><br> <a
-        id="${theme.id}" title="Clone this theme excluding children"
+        class="icon createEpic add-child-icon"></a>
+    <br> 
+    <a id="${theme.id}" title="Clone this theme excluding children"
         class="cloneItem theme icon">
-    <img src="../resources/image/page_white_copy.png"></a>
+        <img src="../resources/image/page_white_copy.png">
+    </a>
     </div>
     <!-- TITLE FIELDS -->
     <div class="titles-theme-epic">
         <!-- TYPE MARK START -->
-        <p class="typeMark">Theme ${theme.id}</p>
+        <p class="typeMark">
+            Theme ${theme.id}
+        </p>
         <!-- TYPE MARK END --> 
         <br style="clear: both" /> 
         <!-- TITLE START -->
-        <p class="titleText ${theme.id}">${theme.title}</p>
+        <p class="titleText ${theme.id}">
+            ${theme.title}
+        </p>
         <textarea placeholder="Title" id="themeTitle${theme.id}"
             class="bindChange titleText hidden-edit title ${theme.id}"
             rows="1" maxlength="100">${theme.title}</textarea>
         <!-- TITLE END --> 
         <!-- DESCRIPTION START -->
-        <p class="description theme-description ${theme.id}">${theme.descriptionWithLinksAndLineBreaks}</p>
+        <p class="description theme-description ${theme.id}">
+            ${theme.descriptionWithLinksAndLineBreaks}
+        </p>
         <textarea placeholder="Description"
             id="themeDescription${theme.id}"
             class="bindChange hidden-edit description ${theme.id}"
@@ -43,12 +51,16 @@
             checked="checked"
         </c:if>
     >
-    <p class="title inline hidden-edit ${theme.id}">Archive theme</p>
-    </input><br>
+    <p class="title inline hidden-edit ${theme.id}">
+        Archive theme
+    </p>
+    <br>
     <button class="save-button hidden-edit ${theme.id}" title="Save">Save</button>
     <button class="cancelButton hidden-edit ${theme.id}" title="Cancel">Cancel</button>
     <c:if test='${theme.archived}'>
-        <p class="title ${theme.id}">Archived</p>
+        <p class="title ${theme.id}">
+            Archived
+        </p>
     </c:if>
     <p class="description ${theme.id}">
         <fmt:formatDate value="${theme.dateArchived}" pattern="yyyy-MM-dd" />

--- a/src/main/webapp/WEB-INF/views/placeholders/theme.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/theme.jsp
@@ -1,0 +1,53 @@
+<li class="parentLi theme ui-state-default editTheme" id="${theme.id}">
+    <div id="icons">
+        <div title="Show epics"
+        class="icon 
+        <c:if test="${theme.children.size() > 0}">expand-icon ui-icon ui-icon-triangle-1-e</c:if>
+        ">
+    </div>
+    <a id="${theme.id}" title="Create new epic"
+        class="icon createEpic add-child-icon"></a><br> <a
+        id="${theme.id}" title="Clone this theme excluding children"
+        class="cloneItem theme icon">
+    <img src="../resources/image/page_white_copy.png"></a>
+    </div>
+    <!-- TITLE FIELDS -->
+    <div class="titles-theme-epic">
+        <!-- TYPE MARK START -->
+        <p class="typeMark">Theme ${theme.id}</p>
+        <!-- TYPE MARK END --> 
+        <br style="clear: both" /> 
+        <!-- TITLE START -->
+        <p class="titleText ${theme.id}">${theme.title}</p>
+        <textarea placeholder="Title" id="themeTitle${theme.id}"
+            class="bindChange titleText hidden-edit title ${theme.id}"
+            rows="1" maxlength="100">${theme.title}</textarea>
+        <!-- TITLE END --> 
+        <!-- DESCRIPTION START -->
+        <p class="description theme-description ${theme.id}">${theme.descriptionWithLinksAndLineBreaks}</p>
+        <textarea placeholder="Description"
+            id="themeDescription${theme.id}"
+            class="bindChange hidden-edit description ${theme.id}"
+            rows="2" maxlength="100000">${theme.description}</textarea>
+        <!-- DESCRIPTION END -->
+    </div>
+    <!-- TITLE FIELDS END --> 
+    <a id="${theme.id}" title="Remove theme"
+        class="icon deleteItem delete-icon"></a> <input type="checkbox"
+    class="marginTopBig inline bindChange hidden-edit ${theme.id}"
+    id="archiveTheme${theme.id}"
+    <c:if test='${theme.archived}'>checked="checked"</c:if>
+    >
+    <p class="title inline hidden-edit ${theme.id}">Archive theme</p>
+    </input><br>
+    <button class="save-button hidden-edit ${theme.id}" title="Save">Save</button>
+    <button class="cancelButton hidden-edit ${theme.id}" title="Cancel">Cancel</button>
+    <c:if test='${theme.archived}'>
+        <p class="title ${theme.id}">Archived</p>
+    </c:if>
+    <p class="description ${theme.id}">
+        <fmt:formatDate value="${theme.dateArchived}"
+            pattern="yyyy-MM-dd" />
+    </p>
+    <br style="clear: both" />
+</li>

--- a/src/main/webapp/WEB-INF/views/placeholders/theme.jsp
+++ b/src/main/webapp/WEB-INF/views/placeholders/theme.jsp
@@ -2,7 +2,9 @@
     <div id="icons">
         <div title="Show epics"
         class="icon 
-        <c:if test="${theme.children.size() > 0}">expand-icon ui-icon ui-icon-triangle-1-e</c:if>
+        <c:if test="${theme.children.size() > 0}">
+            expand-icon ui-icon ui-icon-triangle-1-e
+        </c:if>
         ">
     </div>
     <a id="${theme.id}" title="Create new epic"
@@ -33,10 +35,13 @@
     </div>
     <!-- TITLE FIELDS END --> 
     <a id="${theme.id}" title="Remove theme"
-        class="icon deleteItem delete-icon"></a> <input type="checkbox"
-    class="marginTopBig inline bindChange hidden-edit ${theme.id}"
-    id="archiveTheme${theme.id}"
-    <c:if test='${theme.archived}'>checked="checked"</c:if>
+        class="icon deleteItem delete-icon"></a> 
+    <input type="checkbox"
+        class="marginTopBig inline bindChange hidden-edit ${theme.id}"
+        id="archiveTheme${theme.id}"
+        <c:if test='${theme.archived}'>
+            checked="checked"
+        </c:if>
     >
     <p class="title inline hidden-edit ${theme.id}">Archive theme</p>
     </input><br>
@@ -46,8 +51,7 @@
         <p class="title ${theme.id}">Archived</p>
     </c:if>
     <p class="description ${theme.id}">
-        <fmt:formatDate value="${theme.dateArchived}"
-            pattern="yyyy-MM-dd" />
+        <fmt:formatDate value="${theme.dateArchived}" pattern="yyyy-MM-dd" />
     </p>
     <br style="clear: both" />
 </li>

--- a/src/main/webapp/WEB-INF/views/story-task.jsp
+++ b/src/main/webapp/WEB-INF/views/story-task.jsp
@@ -56,6 +56,9 @@ THE SOFTWARE.
             <div id="story-placeholder" class="placeholder" >
                 <%@ include file="/WEB-INF/views/placeholders/story.jsp"%>
             </div>
+            <div id="task-placeholder" class="placeholder" >
+                <%@ include file="/WEB-INF/views/placeholders/task.jsp"%>
+            </div>
 
             <div id="list-container-div">
                 <ul class="parent-child-list" id="list-container">

--- a/src/main/webapp/WEB-INF/views/story-task.jsp
+++ b/src/main/webapp/WEB-INF/views/story-task.jsp
@@ -65,8 +65,8 @@ THE SOFTWARE.
 
             <div id="list-container-div">
                 <ul class="parent-child-list" id="list-container">
-                    <c:forEach var="story" items="${nonArchivedList}">
-                        <c:if test="${ids == null || ids.contains(story.id)}">
+                    <c:forEach var="story" items="${nonArchivedStories}">
+                        <c:if test="${filterIds == null || filterIds.contains(story.id)}">
                             <%@ include file="/WEB-INF/views/placeholders/story.jsp" %>
                             <c:forEach var="task" items="${story.children}">
                                 <%@ include file="/WEB-INF/views/placeholders/task.jsp" %>

--- a/src/main/webapp/WEB-INF/views/story-task.jsp
+++ b/src/main/webapp/WEB-INF/views/story-task.jsp
@@ -62,6 +62,9 @@ THE SOFTWARE.
                     <c:forEach var="story" items="${nonArchivedList}">
                         <c:if test="${ids == null || ids.contains(story.id)}">
                             <%@ include file="/WEB-INF/views/placeholders/story.jsp" %>
+                            <c:forEach var="task" items="${story.children}">
+                                <%@ include file="/WEB-INF/views/placeholders/task.jsp" %>
+                            </c:forEach>
                         </c:if>
                     </c:forEach>
                 </ul>

--- a/src/main/webapp/WEB-INF/views/story-task.jsp
+++ b/src/main/webapp/WEB-INF/views/story-task.jsp
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
  -->
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
 <%@ page session="false"%>
 <!DOCTYPE html>
 <html>
@@ -52,8 +53,18 @@ THE SOFTWARE.
             <c:import url="header.jsp" />
         </div>
         <div id="main">
+            <div id="story-placeholder" class="placeholder" >
+                <%@ include file="/WEB-INF/views/placeholders/story.jsp"%>
+            </div>
+
             <div id="list-container-div">
-                <ul class="parent-child-list" id="list-container"></ul>
+                <ul class="parent-child-list" id="list-container">
+                    <c:forEach var="story" items="${nonArchivedList}">
+                        <c:if test="${ids == null || ids.contains(story.id)}">
+                            <%@ include file="/WEB-INF/views/placeholders/story.jsp" %>
+                        </c:if>
+                    </c:forEach>
+                </ul>
                 <ul class="parent-child-list" id="archived-list-container"></ul>
             </div>
         </div>

--- a/src/main/webapp/WEB-INF/views/story-task.jsp
+++ b/src/main/webapp/WEB-INF/views/story-task.jsp
@@ -54,9 +54,11 @@ THE SOFTWARE.
         </div>
         <div id="main">
             <div id="story-placeholder" class="placeholder" >
+                <c:set var="story" value="${placeholderStory}"/>
                 <%@ include file="/WEB-INF/views/placeholders/story.jsp"%>
             </div>
             <div id="task-placeholder" class="placeholder" >
+                <c:set var="task" value="${placeholderTask}"/>
                 <%@ include file="/WEB-INF/views/placeholders/task.jsp"%>
             </div>
 

--- a/src/main/webapp/WEB-INF/views/theme-epic.jsp
+++ b/src/main/webapp/WEB-INF/views/theme-epic.jsp
@@ -68,8 +68,8 @@ THE SOFTWARE.
 
             <div id="list-container-div">
                 <ul class="parent-child-list" id="list-container">
-                    <c:forEach var="theme" items="${nonArchivedList}">
-                        <c:if test="${ids == null || ids.contains(theme.id)}">
+                    <c:forEach var="theme" items="${nonArchivedThemes}">
+                        <c:if test="${filterIds == null || filterIds.contains(theme.id)}">
                             <%@ include file="/WEB-INF/views/placeholders/theme.jsp" %>
                             <c:forEach var="epic" items="${theme.children}">
                                 <%@ include file="/WEB-INF/views/placeholders/epic.jsp" %>

--- a/src/main/webapp/WEB-INF/views/theme-epic.jsp
+++ b/src/main/webapp/WEB-INF/views/theme-epic.jsp
@@ -57,8 +57,26 @@ THE SOFTWARE.
         </div>
 
         <div id="main">
+            <div id="theme-placeholder" class="placeholder">
+                <c:set var="theme" value="${placeholderTheme}" />
+                <%@ include file="/WEB-INF/views/placeholders/theme.jsp"%>
+            </div>
+            <div id="epic-placeholder" class="placeholder">
+                <c:set var="epic" value="${placeholderEpic}" />
+                <%@ include file="/WEB-INF/views/placeholders/epic.jsp"%>
+            </div>
+
             <div id="list-container-div">
-                <ul class="parent-child-list" id="list-container"></ul>
+                <ul class="parent-child-list" id="list-container">
+                    <c:forEach var="theme" items="${nonArchivedList}">
+                        <c:if test="${ids == null || ids.contains(theme.id)}">
+                            <%@ include file="/WEB-INF/views/placeholders/theme.jsp" %>
+                            <c:forEach var="epic" items="${theme.children}">
+                                <%@ include file="/WEB-INF/views/placeholders/epic.jsp" %>
+                            </c:forEach>
+                        </c:if>
+                    </c:forEach>
+                </ul>
                 <ul class="parent-child-list" id="archived-list-container"></ul>
             </div>
         </div>

--- a/src/main/webapp/resources/css/styles.css
+++ b/src/main/webapp/resources/css/styles.css
@@ -674,3 +674,7 @@ div#login-error {
 p.addOptionSeries, p.addOption {
 	margin-left: 40px;
 }
+
+.placeholder {
+	display: none;
+}

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -124,7 +124,7 @@ $(document).ready(function () {
         var yyyy = this.getFullYear().toString();
         var mm = (this.getMonth()+1).toString(); // getMonth() is zero-based
         var dd  = this.getDate().toString();
-        return (mm[1]?mm:"0" + mm[0]) + "/" + (dd[1]?dd:"0"+dd[0]) + "/" + yyyy;
+        return yyyy + "-" + (mm[1]?mm:"0" + mm[0]) + "-" + (dd[1]?dd:"0"+dd[0]);
     };
     
     /**
@@ -1095,8 +1095,8 @@ $(document).ready(function () {
             });
 
             //Sets values for all edit fields
-            $("#deadline"+storyId).datepicker({ showWeek: true, firstDay: 1 });
-            $("#added"+storyId).datepicker({ showWeek: true, firstDay: 1 });
+            $("#deadline"+storyId).datepicker({ showWeek: true, firstDay: 1, dateFormat: "yy-mm-dd" });
+            $("#added"+storyId).datepicker({ showWeek: true, firstDay: 1, dateFormat: "yy-mm-dd" });
 
             if (story.deadline == null) {
                 $("#deadline"+storyId).val("");
@@ -2117,6 +2117,8 @@ $(document).ready(function () {
         return newContainer;
     };
 
+    var firstBuild = true;
+
     /**
      * Builds the visible html list using the JSON data
      */
@@ -2124,7 +2126,7 @@ $(document).ready(function () {
     	if ($("#archived-checkbox").prop("checked")) {
     	    $("#archived-list-container").append(generateList(true)).show();
     	}
-    	if (archived != true) {
+    	if (archived != true && !firstBuild) {
     	    $('#list-container').append(generateList(false));    	    
     	}
         editingItems =  new Array();
@@ -2257,6 +2259,7 @@ $(document).ready(function () {
         if (isFilterActive() || disableEditsBoolean || $("#order-by").val() != "prio") {
             $("#list-container").sortable("option", "disabled", true);
         }
+        firstBuild = false;
     };
 
     var setHeightAndMargin = function (value) {
@@ -2371,14 +2374,6 @@ $(document).ready(function () {
             }
         });
     };
-
-    //Sets the first parent with children as fully visible on start
-    if (parents.length > 0) {
-        var firstParent = parents[0];
-        for (var k = 0; k < firstParent.children.length; ++k) {
-            visible[firstParent.children[k].id] = true;
-        }
-    }
 
     $("#list-container").sortable({
         tolerance: 'pointer',

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -442,6 +442,10 @@ $(document).ready(function () {
     var sorting = readCookie("backlogtool-orderby");
     if (sorting != null) {
         $("#order-by").val(sorting);
+        if ($("#order-by").val() == null) {
+            //Failed to set the cookievalue, revert to prio
+            $("#order-by").val("prio");
+        }
     }
 
     // Load checkbox-status for the Archived-checkbox

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -1870,7 +1870,7 @@ $(document).ready(function () {
 	                        newContainer += '<li class="childLi task ui-state-default editTask" parentId="' + currentParent.id + '"' + 'id="' + currentChild.id + '">'
 	                        //TASKTITLE START
 	                        //TYPE MARK START
-	                        +'<p class="marginLeft typeMark">Task</p>'
+	                        +'<p class="marginLeft typeMark">Task ' + currentChild.id + '</p>'
 	                        //TYPE MARK END
 	                        +'<div class="taskTitle ' + currentChild.id + '">'
 	                        +'<p class="taskInfo">'+ addLinksAndLineBreaks(currentChild.title) +'</p>'
@@ -1951,7 +1951,7 @@ $(document).ready(function () {
 	                        //TITLE FIELDS
 	                        +'<div class="padding-left titles-epic-story">'
 	                        //TYPE MARK START
-	                        +'<p class="typeMark">Story</p>'
+	                        +'<p class="typeMark">Story ' + currentChild.id + '</p>'
 	                        //TYPE MARK END
 	                        //THEME START
 	                        +'<p class="theme ' + currentChild.id + '">' + replaceNullWithEmpty(currentChild.themeTitle) + '</p>'
@@ -2087,11 +2087,13 @@ $(document).ready(function () {
 	                    for (var i = 0; i<currentParent.children.length; ++i) {
 	                        var currentChild = currentParent.children[i];
 	                        newContainer += '<li class="childLi epic ui-state-default editEpic" parentId="' + currentParent.id + '"' + 'id="' + currentChild.id + '">'
+	                        +'<div id="icons">'
 	                        +'<a id="' + currentChild.id + '" title="Clone this epic excluding children" class="cloneItem epic icon"><img src="../resources/image/page_white_copy.png"></a>'
+	                        +'</div>'
 	                        //TITLE FIELDS
 	                        +'<div class="padding-left titles-theme-epic">'
 	                        //TYPE MARK START
-	                        +'<p class="typeMark">Epic</p>'
+	                        +'<p class="typeMark">Epic ' + currentChild.id + '</p>'
 	                        //TYPE MARK END
 	                        +'<br style="clear:both" />'
 	                        //TITLE START


### PR DESCRIPTION
All backlog views will now be rendered on the server in JSP instead of locally using Javascript when opening a new view. After updating some items, causing a reload, it will however still fall back to Javascript rendering. The need of falling back to Javascript will be removed in a later change by @ChristofferL. 

Also switched date format for dateArchived and dateCreated.
Finally fixed a bug where it was not possible to switch between views when the backlog was sorted on one of the story specific attributes.
