### PR TITLE
Increased performance for sorting backlogs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>backlogtool</artifactId>
     <name>backlog-tool</name>
     <packaging>war</packaging>
-    <version>1.1.9</version>
+    <version>1.2.0</version>
     <description>
         <![CDATA[A tool for managing backlogs]]>
     </description>

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -23,6 +23,29 @@
  */
 
 /**
+ * Overrides the default outerWidth and outerHeight functions
+ * since they are very slow for items with display: none.
+ * The methods are called a lot by the jQuery.sortable() function,
+ * making drag and drop very slow without these lines.
+ */
+(function ($) {
+    var outerWidth = $.fn.outerWidth;
+    $.fn.outerWidth = function() {
+        if ($(this).css('display') === 'none') {
+            return 0;
+        }
+        return outerWidth.call(this);
+    };
+    var outerHeight = $.fn.outerHeight;
+    $.fn.outerHeight = function() {
+        if ($(this).css('display') === 'none') {
+            return 0;
+        }
+        return outerHeight.call(this);
+    };
+})(jQuery);
+
+/**
  * Creates a cookie and saves locally.
  * 
  * @param name


### PR DESCRIPTION
The drag and drop operation is now more fluent for large backlogs.
The outerWidth and outerHeight functions had to be overridden with a check for display:none-items since calls on such items were the bottleneck.
