### PR TITLE
Disabled atmosphere no-cache headers

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -79,6 +79,10 @@ THE SOFTWARE.
             <param-name>org.atmosphere.useWebSocketAndServlet3</param-name>
             <param-value>false</param-value>
         </init-param>
+        <init-param>
+            <param-name>org.atmosphere.cpr.noCacheHeaders</param-name>
+            <param-value>true</param-value>
+        </init-param>
         <load-on-startup>1</load-on-startup>
     </servlet>
   <servlet-mapping>


### PR DESCRIPTION
Atmosphere forces no-cache by default for all resources, which means that no images or scripts are cached. This change re-enables resource caching.
