### PR TITLE
Fix#2 for moving stories between areas

### DIFF
--- a/src/main/java/com/sonymobile/backlogtool/JSONController.java
+++ b/src/main/java/com/sonymobile/backlogtool/JSONController.java
@@ -1582,6 +1582,7 @@ public class JSONController {
                             newEpic.setPrioInTheme(prioInTheme);
 
                             session.save(newEpic);
+                            newTheme.getChildren().add(newEpic);
                         }
                         story.getEpic().getChildren().remove(story);
                         story.setEpic(newEpic);


### PR DESCRIPTION
This fixes that stories that were moved between areas and had both theme and epic set never got their epic matched in the new area and instead the epic was cloned once for every story.
