### PR TITLE
Align titles closer to text

### DIFF
--- a/src/main/webapp/resources/css/styles.css
+++ b/src/main/webapp/resources/css/styles.css
@@ -274,6 +274,8 @@ p.description {
 .title {
     height: 19px;
     color: #494949;
+    display: table-cell;
+    vertical-align: bottom;
 }
 
 p.theme,p.epic,p.typeMark {


### PR DESCRIPTION
This change alignes titles closer to the text it belongs to
on backlog items.
