### PR TITLE
Enabled users to unselect items

### DIFF
--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -837,13 +837,13 @@ $(document).ready(function () {
     };
 
     /**
-     * The following click event handler unselects all items if
-     * the user presses outside both the li elements and the header.
+     * The following click event handler unselects all items if the user presses
+     * outside both the li elements and the important parts of the header.
      */
     $(document).click(function(event) {
-        if ($(event.target).closest('li,#header').length == 0) {
+        if ($(event.target).closest('li, a, input, button, select').length == 0) {
             selectedItems = new Array();
-            $(".ui-selected").removeClass("ui-selected");
+            $("ul > li.ui-selected").removeClass("ui-selected");
             updateCookie();
         }
     });

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -837,6 +837,18 @@ $(document).ready(function () {
     };
 
     /**
+     * The following click event handler unselects all items if
+     * the user presses outside both the li elements and the header.
+     */
+    $(document).click(function(event) {
+        if ($(event.target).closest('li,#header').length == 0) {
+            selectedItems = new Array();
+            $(".ui-selected").removeClass("ui-selected");
+            updateCookie();
+        }
+    });
+
+    /**
      * Gets the most recently selected item.
      * Optional argument is type specification ("child" or "parent").
      */


### PR DESCRIPTION
Users can unselect selected backlog items again by pressing on a blank part of the page.
