### PR TITLE
Fix for restoring focus after push and deleted elements

### DIFF
--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -473,11 +473,13 @@ $(document).ready(function () {
             if(offset !== null) {
                 // Restore offset
                 var newOffset = $("li#" + offsetObj.id + "." + offsetObj.type).offset();
-                if(newOffset.top != offset.top) {
-                    // Restore focus
-                    var newPos = $(window).scrollTop() + (newOffset.top - offset.top);
-                    $(window).scrollTop(newPos);
-                    inputFocus[0].focus();
+                if(typeof newOffset !== "undefined") {
+                    if(newOffset.top != offset.top) {
+                        // Restore scroll
+                        var newPos = $(window).scrollTop() + (newOffset.top - offset.top);
+                        $(window).scrollTop(newPos);
+                    }
+                    inputFocus[0].focus(); // Restore focus
                 }
                 offset = null;
             }
@@ -970,8 +972,8 @@ $(document).ready(function () {
                 // Restore focus
                 var newPos = $(window).scrollTop() + (newOffset.top - offset.top);
                 $(window).scrollTop(newPos);
-                inputFocus[0].focus();
             }
+            inputFocus[0].focus();
             offset = null;
         }
 


### PR DESCRIPTION
Focus was not always restored when new items were created, since it required that the item had got a new scroll-position (which wasn't always the case). Also added an extra control to avoid error when trying to restore scroll for an item that might no longer exist.
