### PR TITLE
Fix for non-updating Theme-attribute for Stories; when a Story was moved...

### DIFF
--- a/src/main/java/com/sonymobile/backlogtool/MoveController.java
+++ b/src/main/java/com/sonymobile/backlogtool/MoveController.java
@@ -312,6 +312,7 @@ public class MoveController {
                     oldParent.getChildren().remove(child);
                     lastParent.getChildren().add(child);
                     child.setEpic(lastParent);
+                    child.setTheme(lastParent.getTheme());
                     oldParents.add(oldParent);
                     parentsToPush.add(oldParent);
                 }

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -545,6 +545,8 @@ $(document).ready(function () {
                         } else if(view == "theme-epic") {
                             updateEpicLi(children[j]);
                         }
+                    } else if (view == "epic-story") {
+                        updateStoryLiContent(children[j]); // Keeping Theme-box up-to-date
                     }
                     childLi.attr('parentid', p.id);
 


### PR DESCRIPTION
... from one Epic to an other, the Theme was not updated to the new one for the Story.
