### PR TITLE
Httpslinks-change after GLund's review

### DIFF
--- a/src/main/java/com/sonymobile/backlogtool/Util.java
+++ b/src/main/java/com/sonymobile/backlogtool/Util.java
@@ -162,8 +162,7 @@ public final class Util {
         if (text == null) {
             return "";
         }
-        return text.replaceAll("(?i)(http:\\/\\/[^\\s]+)", "<a href='$1'>$1</a>")
-                .replaceAll("(?i)(https:\\/\\/[^\\s]+)", "<a href='$1'>$1</a>")
+        return text.replaceAll("(?i)((https|http):\\/\\/[^\\s]+)", "<a href='$1'>$1</a>")
                 .replaceAll("\\n", "<br />");
     }
 }

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -267,8 +267,7 @@ $(document).ready(function () {
      * Adding line breaks and <a> tags for the param text.
      */
     var addLinksAndLineBreaks = function(text) {
-        return text.replace(/(http:\/\/[^\s]+)/gi, '<a href="$1">$1</a>')
-                .replace(/(https:\/\/[^\s]+)/gi, '<a href="$1">$1</a>')
+        return text.replace(/((https|http):\/\/[^\s]+)/gi, '<a href="$1">$1</a>')
                 .replace(/\n/g, '<br />');
     };
 


### PR DESCRIPTION
Instead of having two regexes for identifying http- and https-links, there is now only one that identifies both.
