### PR TITLE
Fixed indentation for some zoom levels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>backlogtool</artifactId>
     <name>backlog-tool</name>
     <packaging>war</packaging>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
     <description>
         <![CDATA[A tool for managing backlogs]]>
     </description>

--- a/src/main/webapp/resources/css/styles.css
+++ b/src/main/webapp/resources/css/styles.css
@@ -298,7 +298,7 @@ p.theme,p.epic,p.typeMark {
     display: inline;
     float: left;
     font-size: 0.75em;
-    padding: 0.3em;
+    padding: 3px;
     text-align: center;
 }
 

--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -3571,6 +3571,7 @@ $(document).ready(function () {
                 maxWidth = width;
             }
         });
+        maxWidth = Math.ceil(maxWidth*1.1);
         $(".typeMark, .header-id").width(maxWidth);
     };
 
@@ -3913,6 +3914,7 @@ $(document).ready(function () {
         setHeightAndMargin($("#header").height());
         // Delay to let dotdotdot truncate before we check
         delay(updateAllExpandBtns, 10, TIMER_RETRUNCATE);
+        updateTypeMarkWidth();
     });
 
     /*


### PR DESCRIPTION
This fixes that stories were sometimes badly indented for certain zoom
levels in the browser.
