### PR TITLE
Fixed bug when double clicking on expanded title

### DIFF
--- a/src/main/webapp/resources/js/scripts.js
+++ b/src/main/webapp/resources/js/scripts.js
@@ -3729,6 +3729,7 @@ $(document).ready(function () {
             }
             updateCookie();
             addZebraStripesToParents();
+            editingItems.remove({id:id});
         });
     };
 


### PR DESCRIPTION
After double clicking on an expanded title and then re-opening the item, it could not be saved.
